### PR TITLE
Fix CategoryDisplay achievements without category

### DIFF
--- a/app/controllers/AchievementController.php
+++ b/app/controllers/AchievementController.php
@@ -58,7 +58,7 @@ class AchievementController extends BaseController {
                 return isset($objective->type) && ($objective->type !== 'Text' || $objective->text !== '');
             });
 
-            if ($achievement->hasFLag('CategoryDisplay')) {
+            if ($achievement->hasFLag('CategoryDisplay') && !is_null($achievement->category)) {
                 /** @var Achievement $categoryAchievement */
                 foreach ($achievement->category->achievements as $categoryAchievement) {
                     $isCategoryDisplay = $categoryAchievement->hasFlag('CategoryDisplay');


### PR DESCRIPTION
Example: [Bloodstone Fen Mastery (3046)](https://gw2treasures.com/achievement/3046)