### PR TITLE
Test crazy-max/docker-bake-action@fix-bake-def in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Build the Docker image
-      uses: docker/bake-action@v2.3.0
+      uses: crazy-max/docker-bake-action@fix-bake-def
       with:
         files: |
           ./docker-compose.yml


### PR DESCRIPTION
This PR replaces docker/bake-action with crazy-max/docker-bake-action@fix-bake-def (see docker/bake-action#131).

docker/bake-action@v3 breaks this build without setting `provenance: false`, this tests a potential bugfix