### PR TITLE
Add correct types for gw2e-chat-codes

### DIFF
--- a/apps/web/types/gw2e-chat-codes.d.ts
+++ b/apps/web/types/gw2e-chat-codes.d.ts
@@ -1,0 +1,44 @@
+import { CodeType } from 'gw2e-chat-codes/build/src/static';
+
+declare module 'gw2e-chat-codes' {
+  function decode(chatCode: string): false | {
+    type: Exclude<CodeType, 'item' | 'objective' | 'build'>;
+    id: number;
+  } | {
+    type: 'item';
+    id: number;
+    quantity: number;
+    skin: undefined | number;
+    upgrades: undefined | [number] | [number, number];
+  } | {
+    type: 'objective';
+    id: string;
+  } | {
+    type: 'build';
+    profession: number;
+    specialization1: number;
+    traitChoices1: number[];
+    specialization2: number;
+    traitChoices2: number[];
+    specialization3: number;
+    traitChoices3: number[];
+    terrestrialHealSkill: number;
+    terrestrialUtilitySkill1: number;
+    terrestrialUtilitySkill2: number;
+    terrestrialUtilitySkill3: number;
+    terrestrialEliteSkill: number;
+    aquaticHealSkill: number;
+    aquaticUtilitySkill1: number;
+    aquaticUtilitySkill2: number;
+    aquaticUtilitySkill3: number;
+    aquaticEliteSkill: number;
+    terrestrialPet1: number | undefined;
+    terrestrialPet2: number | undefined;
+    aquaticPet1: number | undefined;
+    aquaticPet2: number | undefined;
+    terrestrialLegend1: number | undefined;
+    terrestrialLegend2: number | undefined;
+    aquaticLegend1: number | undefined;
+    aquaticLegend2: number | undefined;
+  };
+}


### PR DESCRIPTION
The types provided by gw2e-chat-codes are not correct (missing properties for `type: 'item'` and unspecific `type`).

This is something that should be fixed upstream in [gw2efficiency/gw2e-chat-codes](https://github.com/gw2efficiency/chat-codes) (cc @queicherius)

```diff
 export declare function decode(chatCode: string): false | {
-    type: CodeType;
+    type: Exclude<CodeType, 'item' | 'objective' | 'build'>;
     id: number;
 } | {
+    type: 'item';
+    id: number;
+    quantity: number;
+    skin: undefined | number;
+    upgrades: undefined | [number] | [number, number];
+} | {
-    type: CodeType;
+    type: 'objective';
     id: string;
 } | {
-    type: CodeType;
+    type: 'build';
     profession: number;
     specialization1: number;
     traitChoices1: number[];
     specialization2: number;
     traitChoices2: number[];
     specialization3: number;
     traitChoices3: number[];
     terrestrialHealSkill: number;
     terrestrialUtilitySkill1: number;
     terrestrialUtilitySkill2: number;
     terrestrialUtilitySkill3: number;
     terrestrialEliteSkill: number;
     aquaticHealSkill: number;
     aquaticUtilitySkill1: number;
     aquaticUtilitySkill2: number;
     aquaticUtilitySkill3: number;
     aquaticEliteSkill: number;
     terrestrialPet1: number | undefined;
     terrestrialPet2: number | undefined;
     aquaticPet1: number | undefined;
     aquaticPet2: number | undefined;
     terrestrialLegend1: number | undefined;
     terrestrialLegend2: number | undefined;
     aquaticLegend1: number | undefined;
     aquaticLegend2: number | undefined;
 };
```