### PR TITLE
Fix build caching for @gw2treasures/icons

### DIFF
--- a/packages/icons/turbo.json
+++ b/packages/icons/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "outputs": ["dist"],
+      "outputs": ["dist/**"],
       "inputs": ["build.ts", "icons/*.svg"],
       "dependsOn": ["^build"]
     }


### PR DESCRIPTION
See if this fixes the CI errors
> Module not found: Can't resolve '@gw2treasures/icons'