### PR TITLE
Fix ItemTable loading

### DIFF
--- a/apps/web/components/ItemTable/ItemTable.tsx
+++ b/apps/web/components/ItemTable/ItemTable.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { Notice } from '@gw2treasures/ui/components/Notice/Notice';
 import { getLanguage, getTranslate } from '../I18n/getTranslate';
 import type { AvailableColumn, AvailableColumns, ExtraColumn, GlobalColumnId, ItemTableQuery, OrderBy, QueryModel } from './types';
+import { loadItems, loadTotalItemCount } from './ItemTable.actions';
 
 export interface ItemTableProps<ExtraColumnId extends string, Model extends QueryModel> {
   query: ItemTableQuery<Model>;
@@ -21,7 +22,12 @@ export const ItemTable = async <ExtraColumnId extends string = never, Model exte
 
   return (
     <ErrorBoundary fallback={<Notice type="error">Error loading items.</Notice>}>
-      <ClientComponent query={signedQuery} availableColumns={availableColumns} {...props}/>
+      <ClientComponent
+        availableColumns={availableColumns}
+        loadItems={loadItems.bind(null, signedQuery)}
+        loadTotalItemCount={loadTotalItemCount.bind(null, signedQuery)}
+        mappingConfig={query.mapToItem && query.model ? { mapToItem: query.mapToItem, model: query.model } : undefined}
+        {...props}/>
     </ErrorBoundary>
   );
 };

--- a/apps/web/components/ItemTable/types.ts
+++ b/apps/web/components/ItemTable/types.ts
@@ -51,3 +51,8 @@ export type AvailableColumn<ColumnId extends string, Model extends QueryModel = 
 }
 
 export type AvailableColumns<ColumnId extends string> = Record<ColumnId, AvailableColumn<ColumnId>>
+
+export interface MappingConfig<Model extends QueryModel = 'item'> {
+  model: Model;
+  mapToItem: ColumnModelTypes[Model]['map']
+}


### PR DESCRIPTION
When multiple ItemTables were used on one page, only the first item table loaded, all other tables were not sending their server actions for some reason. This now binds a unique server action into the client component, which should hopefully fix this issue (the issue was not reproducible in dev). The client component now also doesn't need to know the query anymore.