### PR TITLE
Fix ItemTable loading

### DIFF
--- a/apps/web/components/ItemTable/ItemTable.tsx
+++ b/apps/web/components/ItemTable/ItemTable.tsx
@@ -24,8 +24,16 @@ export const ItemTable = async <ExtraColumnId extends string = never, Model exte
     <ErrorBoundary fallback={<Notice type="error">Error loading items.</Notice>}>
       <ClientComponent
         availableColumns={availableColumns}
-        loadItems={loadItems.bind(null, signedQuery)}
-        loadTotalItemCount={loadTotalItemCount.bind(null, signedQuery)}
+        // eslint-disable-next-line require-await
+        loadItems={async (options) => {
+          'use server';
+          return loadItems(signedQuery, options);
+        }}
+        // eslint-disable-next-line require-await
+        loadTotalItemCount={async () => {
+          'use server';
+          return loadTotalItemCount(signedQuery);
+        }}
         mappingConfig={query.mapToItem && query.model ? { mapToItem: query.mapToItem, model: query.model } : undefined}
         {...props}/>
     </ErrorBoundary>


### PR DESCRIPTION
This is another attempt to fix ItemTable loading because #660 didn't work. This time I'm trying server action closures. These are also encrypted, so we might be able to drop the signed query in the future?