### PR TITLE
Workaround broken `not-found` in next.js

### DIFF
--- a/apps/web/app/[language]/item/[id]/not-found.tsx
+++ b/apps/web/app/[language]/item/[id]/not-found.tsx
@@ -3,7 +3,7 @@ import { HeroLayout } from '@/components/Layout/HeroLayout';
 
 export default function ItemNotFound(params: any) {
   return (
-    <HeroLayout hero={<Headline id="test">Item not found</Headline>}>
+    <HeroLayout hero={<Headline id="test">Item not found</Headline>} skipPreload>
       <p>We couldn&apos;t find the item. The item might not have been added to the API yet.</p>
     </HeroLayout>
   );

--- a/apps/web/app/[language]/not-found.tsx
+++ b/apps/web/app/[language]/not-found.tsx
@@ -1,20 +1,15 @@
 import { Headline } from '@gw2treasures/ui/components/Headline/Headline';
-import { HeroLayout } from '@/components/Layout/HeroLayout';
-import { getCurrentUrl } from '@/lib/url';
 import { getLanguage } from '@/lib/translate';
 import Link from 'next/link';
-import { Notice } from '@gw2treasures/ui/components/Notice/Notice';
+import { HeroLayout } from '@/components/Layout/HeroLayout';
 
 export default function NotFound() {
-  const url = getCurrentUrl();
   const language = getLanguage();
-
-  url.host = `${language}.legacy.gw2treasures.com`;
+  const legacy = `https://${language}.legacy.gw2treasures.com/`;
 
   return (
-    <HeroLayout color="#b7000d" hero={<Headline id="404">404 - Page not found</Headline>}>
-      <Notice>Not all pages have been migrated to the new version of gw2treasures.com yet, you can also check if this page exists in the <a href={url.toString()}>legacy version</a>.</Notice>
-      <p>We couldn&apos;t find the page you requested. You can try the search to find the content you were looking for.</p>
+    <HeroLayout hero={<Headline id="404">404 - Page not found</Headline>} skipPreload>
+      <p>We couldn&apos;t find the page you requested. You can try the search to find the content you were looking for. Not all pages have been migrated to the new version of gw2treasures.com yet, you can also check if this page exists in the <a href={legacy}>legacy version</a>.</p>
       <p>If you think this page should exist, you can <Link href="/about">report it or even contribute yourself</Link>.</p>
     </HeroLayout>
   );

--- a/apps/web/components/Layout/HeroLayout.tsx
+++ b/apps/web/components/Layout/HeroLayout.tsx
@@ -9,10 +9,13 @@ export interface HeroLayoutProps {
   hero: ReactNode;
   color?: CSSProperties['--hero-color'];
   toc?: boolean;
+  skipPreload?: boolean;
 }
 
-export const HeroLayout: FC<HeroLayoutProps> = ({ children, hero, color, toc }) => {
-  preload(heroMask.src, { as: 'image' });
+export const HeroLayout: FC<HeroLayoutProps> = ({ children, hero, color, toc, skipPreload }) => {
+  if(!skipPreload) {
+    preload(heroMask.src, { as: 'image' });
+  }
 
   return (
     <div style={{ '--hero-color': color ?? '#b7000d' }}>


### PR DESCRIPTION
`not-found.tsx` is prerendered for every page request, and as such calls the layouts `preload()` on every page, even if that specific layout is not used. So now we are skipping preload in the hero layout if it is used in a not-found page. See vercel/next.js#61765

Additionaly the not-found page is not always rerendered when client navigating, and `headers()` gets outdated. Because of that I replaced the dynamic link to the legacy version with a static link to homepage :(