### PR TITLE
Fix IconSprite component for react@18 and webpack

### DIFF
--- a/packages/ui/icons/IconSprite.tsx
+++ b/packages/ui/icons/IconSprite.tsx
@@ -1,17 +1,26 @@
 import { forwardRef, type SVGAttributes } from 'react';
-import sprite from '@gw2treasures/icons/sprite.svg';
 import type { IconName } from '@gw2treasures/icons';
-import { preload } from 'react-dom';
+import reactDOM from 'react-dom';
 import styles from './IconSprite.module.css';
 
 export interface IconSpriteProps extends SVGAttributes<SVGSVGElement> {
   icon: IconName,
 }
 
+// load sprite as asset module. If just importing, it will be loaded as Next.js image object ({ src, width, … })
+// and is not compatible with just webpack used outside of Next.js (i.e. gw2.me extensions)
+const sprite = new URL('@gw2treasures/icons/sprite.svg', import.meta.url).toString();
+
 export const IconSprite = forwardRef<SVGSVGElement, IconSpriteProps>(function IconSprite({ icon, ...props }, ref) {
-  preload(sprite.src, { as: 'image' });
+  // preload in react@canary (has preload), react@18 has no preload
+  // TODO: remove once using react@beta or react@19
+  if('preload' in reactDOM && typeof reactDOM.preload === 'function') {
+    reactDOM.preload(sprite, { as: 'image' });
+  }
 
   return (
-    <svg ref={ref} viewBox="0 0 16 16" {...props}><use href={sprite.src + '#' + icon} className={styles[icon]}/></svg>
+    <svg ref={ref} viewBox="0 0 16 16" {...props}>
+      <use href={`${sprite}#${icon}`} className={styles[icon]}/>
+    </svg>
   );
 });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gw2treasures/ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GW2Treasures/gw2treasures.com.git"


### PR DESCRIPTION
- use `preload` only if available (`react@canary`/`react@beta`)
- import sprite as asset module to make it work with plain webpack outside Next.js