### PR TITLE
Revert "Enable PPR for home page"

### DIFF
--- a/apps/web/app/[language]/(home)/page.tsx
+++ b/apps/web/app/[language]/(home)/page.tsx
@@ -125,5 +125,3 @@ export function generateMetadata({ params }: { params: { language: Language }}) 
     alternates: getAlternateUrls('/', params.language)
   };
 }
-
-export const experimental_ppr = true;

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   experimental: {
     outputFileTracingRoot: path.join(__dirname, '../../'),
     reactCompiler: true,
-    ppr: 'incremental'
   },
   redirects: () => [{ source: '/wizardsvault', destination: '/wizards-vault', permanent: true }],
   transpilePackages: ['@gw2treasures/ui'],


### PR DESCRIPTION
Reverts GW2Treasures/gw2treasures.com#1280

> Refused to load the script 'https://en.gw2treasures.com/_next/static/chunks/webpack-404f23c33705efd3.js' because it violates the following Content Security Policy directive: "script-src 'self' 'nonce-MjE2YzkyNWEtNzEzMi00MmFkLWFjMzUtNTBlNjM0ZDY5NTA3' 'strict-dynamic'". Note that 'strict-dynamic' is present, so host-based allowlisting is disabled. Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.

