### PR TITLE
Fix achievement category DataTables in dev-mode

### DIFF
--- a/apps/web/app/[language]/achievement/category/[id]/page.tsx
+++ b/apps/web/app/[language]/achievement/category/[id]/page.tsx
@@ -95,10 +95,10 @@ async function AchievementCategoryPage({ params: { language, id }}: AchievementC
         <CurrentAchievements.Column id="points" align="right" title="AP" sortBy="points">
           {({ points }) => <AchievementPoints points={points}/>}
         </CurrentAchievements.Column>
-        <CurrentAchievements.Column id="mastery" title={<><Icon icon="mastery"/> Mastery</>} sortBy="mastery">
+        <CurrentAchievements.Column id="mastery" title={<MasteryColumnHeader/>} sortBy="mastery">
           {({ mastery }) => mastery}
         </CurrentAchievements.Column>
-        <CurrentAchievements.Column id="title" title={<><Icon icon="title"/> Title</>} sortBy={({ rewardsTitle }) => rewardsTitle.length}>
+        <CurrentAchievements.Column id="title" title={<TitleColumnHeader/>} sortBy={({ rewardsTitle }) => rewardsTitle.length}>
           {({ rewardsTitle }) => rewardsTitle.map((title) => <span key={title.id} dangerouslySetInnerHTML={{ __html: format(localizedName(title, language)) }}/>)}
         </CurrentAchievements.Column>
         <CurrentAchievements.Column id="items" title="Items" sortBy={({ rewardsItem }) => rewardsItem.length}>
@@ -151,3 +151,6 @@ export async function generateMetadata({ params }: AchievementCategoryPageProps)
     title: localizedName(achievementCategory, params.language)
   };
 }
+
+const MasteryColumnHeader = () => (<><Icon icon="mastery"/> Mastery</>);
+const TitleColumnHeader = () => (<><Icon icon="title"/> Title</>);

--- a/apps/web/app/[language]/achievement/uncategorized/page.tsx
+++ b/apps/web/app/[language]/achievement/uncategorized/page.tsx
@@ -45,10 +45,10 @@ async function AchievementUncategorizedPage({ params: { language }}: { params: {
         <UncategorizedAchievements.Column id="points" align="right" title="AP" sortBy="points">
           {({ points }) => <AchievementPoints points={points}/>}
         </UncategorizedAchievements.Column>
-        <UncategorizedAchievements.Column id="mastery" title={<><Icon icon="mastery"/> Mastery</>} sortBy="mastery">
+        <UncategorizedAchievements.Column id="mastery" title={<MasteryColumnHeader/>} sortBy="mastery">
           {({ mastery }) => mastery}
         </UncategorizedAchievements.Column>
-        <UncategorizedAchievements.Column id="title" title={<><Icon icon="title"/> Title</>} sortBy={({ rewardsTitle }) => rewardsTitle.length}>
+        <UncategorizedAchievements.Column id="title" title={<TitleColumnHeader/>} sortBy={({ rewardsTitle }) => rewardsTitle.length}>
           {({ rewardsTitle }) => rewardsTitle.map((title) => <span key={title.id} dangerouslySetInnerHTML={{ __html: format(localizedName(title, language)) }}/>)}
         </UncategorizedAchievements.Column>
         <UncategorizedAchievements.Column id="items" title="Items" sortBy={({ rewardsItem }) => rewardsItem.length}>
@@ -73,3 +73,6 @@ export default AchievementUncategorizedPage;
 export const metadata = {
   title: 'Uncategorized Achievements'
 };
+
+const MasteryColumnHeader = () => (<><Icon icon="mastery"/> Mastery</>);
+const TitleColumnHeader = () => (<><Icon icon="title"/> Title</>);


### PR DESCRIPTION
For some super weird reason Next.js did not like inline JSX (with children prop?) in the title. 

```raw
TypeError: Cannot assign to read only property 'children' of object '#<Object>'
```

Creating a wrapper component without `children` prop works.

These tables will be replaced sooner or later anyway with a common `AchievementTable` component.