### PR TITLE
Improve `items.views` job

### DIFF
--- a/apps/worker/src/jobs/items/views.ts
+++ b/apps/worker/src/jobs/items/views.ts
@@ -1,30 +1,40 @@
 import { db } from '../../db';
 import { batch } from '../helper/batch';
+import { toId } from '../helper/toId';
 import { Job } from '../job';
 
 export const ItemsViews: Job = {
   run: async () => {
-    // get date 24 hours ago
-    const past24hours = new Date();
-    past24hours.setDate(past24hours.getDate() - 1);
+    // get date 7 days ago
+    const pastWeek = new Date();
+    pastWeek.setDate(pastWeek.getDate() - 7);
+
+    // get all ids with >0 page views, because we potentially have to set those to 0
+    const allItemIdsWithExistingPageViews = await db.item.findMany({
+      select: { id: true },
+      where: { views: { gt: 0 }}
+    }).then((ids) => ids.map(toId));
 
     // get views grouped by item id
-    const views = await db.pageView.groupBy({
-      by: ['pageId'],
-      where: { page: 'item', time: { gte: past24hours }, pageId: { not: 0 }},
-      _count: true,
+    const views = await db.pageView_daily.groupBy({
+      by: ['page', 'pageId'],
+      where: { page: 'item', bucket: { gte: pastWeek }, pageId: { not: 0 }},
+      _sum: { count: true },
     });
 
     // create id => views record
-    const viewsById: Record<number, number> = Object.fromEntries(views.map(({ pageId, _count }) => [pageId, _count]));
+    const viewsById: Record<number, number> = Object.fromEntries(views.map(
+      ({ pageId, _sum }) => [pageId, _sum.count ?? 0]
+    ));
 
     // get all item ids that have views
-    const idsWithViews = views.map(({ pageId }) => pageId!);
+    const idsWithViews = views.map(({ pageId }) => pageId);
+    const idsWithoutViews = allItemIdsWithExistingPageViews.filter((id) => !idsWithViews.includes(id));
 
     // set all items with 0 views to 0
-    await db.$transaction(batch(idsWithViews, 5000).map(
+    await db.$transaction(batch(idsWithoutViews, 5000).map(
       (ids) => db.item.updateMany({
-        where: { id: { notIn: ids }},
+        where: { id: { in: ids }},
         data: { views: 0 }
       })
     ));
@@ -32,7 +42,7 @@ export const ItemsViews: Job = {
     // update views for all items that had views
     for(const ids of batch(idsWithViews, 500)) {
       await db.$transaction(ids.map((id) =>
-        db.item.updateMany({ where: { id }, data: { views: viewsById[id] ?? 0 }})
+        db.item.updateMany({ where: { id }, data: { views: viewsById[id] }})
       ));
     }
 


### PR DESCRIPTION
- Fix bug resetting all views
- Include page views of past 7 days (was 24h before)
- Use aggregated `PageView_daily` view