### PR TITLE
Allow `access_token` query parameter to pass API key

### DIFF
--- a/apps/web/middleware/api-key.ts
+++ b/apps/web/middleware/api-key.ts
@@ -34,5 +34,11 @@ function getApiKeyFromRequest(request: NextRequest): string | undefined {
     return apiKey ?? undefined;
   }
 
+  if(request.nextUrl.searchParams.has('access_token')) {
+    const accessToken = request.nextUrl.searchParams.get('access_token');
+
+    return accessToken ?? undefined;
+  }
+
   return undefined;
 }


### PR DESCRIPTION
Only merge this in case DRF can't pass the default `apiKey`