### PR TITLE
Revert "Enable `relationJoins`"

### DIFF
--- a/apps/web/app/[language]/item/[id]/data.ts
+++ b/apps/web/app/[language]/item/[id]/data.ts
@@ -28,10 +28,7 @@ export const getItem = cache((id: number, language: Language) => {
       _count: {
         select: { ingredient: true, suffixIn: true, contains: true, containedIn: true, mysticForgeIngredient: true }
       }
-    },
-
-    // this query is too big when done with joins,
-    relationLoadStrategy: 'query',
+    }
   });
 }, ['item'], { revalidate: 60 });
 

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider = "prisma-client-js"
   binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
-  previewFeatures = ["views", "relationJoins"]
+  previewFeatures = ["views"]
 }
 
 datasource db {


### PR DESCRIPTION
Reverts GW2Treasures/gw2treasures.com#1520

This was causing this error:

```raw
[pod/next-5b4875c676-9665h/next] > [2f97c92e-8c4e-42e5-bbab-b76c0a61c137] GET /skill/9211
[pod/next-5b4875c676-9665h/next] prisma:error
[pod/next-5b4875c676-9665h/next] Invalid `prisma.skill.findUnique()` invocation:
[pod/next-5b4875c676-9665h/next]
[pod/next-5b4875c676-9665h/next]
[pod/next-5b4875c676-9665h/next] The column `t3.language` does not exist in the current database.
[pod/next-5b4875c676-9665h/next] PrismaClientKnownRequestError:
[pod/next-5b4875c676-9665h/next] Invalid `prisma.skill.findUnique()` invocation:
[pod/next-5b4875c676-9665h/next]
[pod/next-5b4875c676-9665h/next]
[pod/next-5b4875c676-9665h/next] The column `t3.language` does not exist in the current database.
[pod/next-5b4875c676-9665h/next]     at Ln.handleRequestError (/app/node_modules/@prisma/client/runtime/library.js:121:7753)
[pod/next-5b4875c676-9665h/next]     at Ln.handleAndLogRequestError (/app/node_modules/@prisma/client/runtime/library.js:121:7061)
[pod/next-5b4875c676-9665h/next]     at Ln.request (/app/node_modules/@prisma/client/runtime/library.js:121:6745)
[pod/next-5b4875c676-9665h/next]     at async l (/app/node_modules/@prisma/client/runtime/library.js:130:9633)
[pod/next-5b4875c676-9665h/next]     at async a.revalidate (/app/apps/web/.next/server/chunks/3789.js:1:11421)
[pod/next-5b4875c676-9665h/next]     at async /app/apps/web/.next/server/app/api/achievements/route.js:1:3042
[pod/next-5b4875c676-9665h/next]     at async /app/apps/web/.next/server/chunks/1179.js:1:5471
[pod/next-5b4875c676-9665h/next]     at async /app/apps/web/.next/server/app/api/achievements/route.js:1:3113
[pod/next-5b4875c676-9665h/next]     at async Promise.all (index 0)
[pod/next-5b4875c676-9665h/next]     at async B (/app/apps/web/.next/server/chunks/3789.js:1:8945) {
[pod/next-5b4875c676-9665h/next]   code: 'P2022',
[pod/next-5b4875c676-9665h/next]   clientVersion: '5.19.0',
[pod/next-5b4875c676-9665h/next]   meta: { modelName: 'Skill', column: 't3.language' },
[pod/next-5b4875c676-9665h/next]   digest: '1005549487'
[pod/next-5b4875c676-9665h/next] }
```