### PR TITLE
Skip linting during build in CI and docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
           turbo2-cache-build-${{ runner.os }}-
     - name: Run Build
       run: npm run build
+      env:
+        SKIP_LINT: true
 
   docker:
     name: Docker (${{ matrix.platform }})

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -35,6 +35,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV CI=true
+ENV SKIP_LINT=true
 
 RUN npm install --os=linux --libc=musl --cpu=x64 sharp@${sharp_version}
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -8,6 +8,9 @@ const nextConfig = {
     outputFileTracingRoot: path.join(__dirname, '../../'),
     reactCompiler: true,
   },
+  eslint: {
+    ignoreDuringBuilds: !!process.env.SKIP_LINT
+  },
   redirects: () => [{ source: '/wizardsvault', destination: '/wizards-vault', permanent: true }],
   transpilePackages: ['@gw2treasures/ui'],
   output: 'standalone',

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -8,7 +8,8 @@
       "outputs": [
         ".next/**",
         "!.next/cache/**"
-      ]
+      ],
+      "env": ["SKIP_LINT"]
     },
     "dev": {
       "dependsOn": [


### PR DESCRIPTION
There already is a dedicated lint CI workflow, so no need to do duplicate work