### PR TITLE
`use` user instead of loading context

### DIFF
--- a/apps/web/app/[language]/(home)/page.tsx
+++ b/apps/web/app/[language]/(home)/page.tsx
@@ -17,9 +17,7 @@ import { getAlternateUrls } from '@/lib/url';
 import { PageView } from '@/components/PageView/PageView';
 import type { PageProps } from '@/lib/next';
 
-function HomePage({ params: { language }, searchParams }: PageProps) {
-  console.log(searchParams);
-
+function HomePage({ params: { language }}: PageProps) {
   return (
     <HeroLayout hero={(
       <div className={styles.hero}>

--- a/apps/web/app/[language]/minis/[id]/wardrobe.tsx
+++ b/apps/web/app/[language]/minis/[id]/wardrobe.tsx
@@ -18,7 +18,7 @@ const requiredScopes = [Scope.GW2_Account, Scope.GW2_Unlocks];
 export const Wardrobe: FC<WardrobeProps> = ({ miniId }) => {
   const user = useUser();
 
-  if(!user.loading && !user.user) {
+  if(!user) {
     return null;
   }
 

--- a/apps/web/app/[language]/skin/[id]/wardrobe.tsx
+++ b/apps/web/app/[language]/skin/[id]/wardrobe.tsx
@@ -18,7 +18,7 @@ const requiredScopes = [Scope.GW2_Account, Scope.GW2_Unlocks];
 export const Wardrobe: FC<WardrobeProps> = ({ skinId }) => {
   const user = useUser();
 
-  if(!user.loading && !user.user) {
+  if(!user) {
     return null;
   }
 

--- a/apps/web/app/[language]/wizards-vault/objectives.tsx
+++ b/apps/web/app/[language]/wizards-vault/objectives.tsx
@@ -40,7 +40,7 @@ export const WizardVaultObjectives: FC<WizardVaultObjectivesProps> = ({ objectiv
         <Notice type="error">Error loading your accounts from the Guild Wars 2 API.</Notice>
       )}
 
-      {!user.loading && !user.user ? (
+      {!user ? (
         <Notice>
           <Link href={loginUrl}>Login</Link> to see your personal Wizard&apos;s Vault objectives and progress.
         </Notice>
@@ -61,7 +61,7 @@ export const WizardVaultObjectives: FC<WizardVaultObjectivesProps> = ({ objectiv
           </tr>
         </thead>
         <tbody>
-          {user.user && accounts.loading && (
+          {user && accounts.loading && (
             <tr>
               <td>Loading accounts <Icon icon="loading"/></td>
             </tr>

--- a/apps/web/app/[language]/wizards-vault/page.tsx
+++ b/apps/web/app/[language]/wizards-vault/page.tsx
@@ -12,6 +12,8 @@ import { AstralAcclaim } from '@/components/Format/AstralAcclaim';
 import { pageView } from '@/lib/pageView';
 import { UnknownItem } from '@/components/Item/UnknownItem';
 import { LinkButton } from '@gw2treasures/ui/components/Form/Button';
+import { Suspense } from 'react';
+import { Skeleton } from '@/components/Skeleton/Skeleton';
 
 export default async function WizardsVaultPage() {
   const [listings, objectiveWaypoints] = await Promise.all([
@@ -33,7 +35,9 @@ export default async function WizardsVaultPage() {
     <HeroLayout hero={<Headline id="wizards-vault">Wizard&apos;s Vault</Headline>} color="#ff9800" toc>
       <Headline id="objectives" actions={<LinkButton icon="chevron-right" href="/wizards-vault/objectives" appearance="tertiary">All Objectives</LinkButton>}>Objectives</Headline>
       <ErrorBoundary fallback={<Notice type="error">Unknown error</Notice>}>
-        <WizardVaultObjectives objectiveWaypoints={objectiveWaypoints}/>
+        <Suspense fallback={<Skeleton/>}>
+          <WizardVaultObjectives objectiveWaypoints={objectiveWaypoints}/>
+        </Suspense>
       </ErrorBoundary>
 
       <Headline id="rewards">Rewards</Headline>

--- a/apps/web/components/Achievement/AccountAchievementProgress.tsx
+++ b/apps/web/components/Achievement/AccountAchievementProgress.tsx
@@ -3,13 +3,12 @@
 import type { FC } from 'react';
 import { Skeleton } from '../Skeleton/Skeleton';
 import { Icon } from '@gw2treasures/ui';
-import { useGw2Accounts } from '../Gw2Api/use-gw2-accounts';
 import { ProgressCell } from './ProgressCell';
 import { useSubscription } from '../Gw2Api/Gw2AccountSubscriptionProvider';
 import { Scope } from '@gw2me/client';
 import type { Achievement } from '@gw2treasures/database';
 import { Tip } from '@gw2treasures/ui/components/Tip/Tip';
-import { Gw2AccountHeaderCells } from '../Gw2Api/Gw2AccountTableCells';
+import { Gw2AccountBodyCells, Gw2AccountHeaderCells } from '../Gw2Api/Gw2AccountTableCells';
 import { FormatNumber } from '../Format/FormatNumber';
 
 const requiredScopes = [Scope.GW2_Progression];
@@ -26,13 +25,11 @@ export interface AccountAchievementProgressCellProps {
 
 export const AccountAchievementProgressHeader: FC = () => <Gw2AccountHeaderCells requiredScopes={requiredScopes} small/>;
 
-export const AccountAchievementProgressRow: FC<RowProps> = ({ achievement, bitId }) => {
-  const accounts = useGw2Accounts(requiredScopes);
-
-  return !accounts.loading && !accounts.error && accounts.accounts.map((account) => (
-    <AccountAchievementProgressCell key={account.id} achievement={achievement} bitId={bitId} accountId={account.id}/>
-  ));
-};
+export const AccountAchievementProgressRow: FC<RowProps> = ({ achievement, bitId }) => (
+  <Gw2AccountBodyCells requiredScopes={requiredScopes}>
+    <AccountAchievementProgressCell achievement={achievement} bitId={bitId} accountId={undefined as never}/>
+  </Gw2AccountBodyCells>
+);
 
 export const AccountAchievementProgressCell: FC<AccountAchievementProgressCellProps> = ({ achievement, accountId, bitId }) => {
   const achievements = useSubscription('achievements', accountId);

--- a/apps/web/components/Format/FormatConfigDialog.tsx
+++ b/apps/web/components/Format/FormatConfigDialog.tsx
@@ -11,6 +11,7 @@ import { Icon } from '@gw2treasures/ui';
 import { FlexRow } from '@gw2treasures/ui/components/Layout/FlexRow';
 import styles from './FormatConfigDialog.module.css';
 import { useUser } from '../User/use-user';
+import { withSuspense } from '@/lib/with-suspense';
 
 export interface FormatConfigDialogProps {
   open: boolean;
@@ -55,16 +56,10 @@ export const FormatConfigDialog: FC<FormatConfigDialogProps> = ({ open, onClose 
     return availableRegions.map((region) => ({ value: region, label: `${formatter.of(region)} (${region})` }));
   }, [currentLanguage]);
 
-  const { user } = useUser();
-
   return (
     <Dialog title="Formatting Settings" onClose={onClose} open={open}>
       <div className={styles.layout}>
-        {!user && (
-          <div className={styles.box}>
-            <FlexRow><Icon icon="cookie"/> Changing your settings will store cookies in your browser.</FlexRow>
-          </div>
-        )}
+        <FormatConfigDialogCookieNote/>
         <div className={styles.inputs}>
           <Label label="Language">
             <Select options={[{ label: `Current language (${currentLanguage})`, value: 'auto' }, ...languages]} value={language} onChange={(language) => setLocale(language, region)}/>
@@ -87,3 +82,13 @@ export const FormatConfigDialog: FC<FormatConfigDialogProps> = ({ open, onClose 
     </Dialog>
   );
 };
+
+const FormatConfigDialogCookieNote = withSuspense(() => {
+  const user = useUser();
+
+  return !user && (
+    <div className={styles.box}>
+      <FlexRow><Icon icon="cookie"/> Changing your settings will store cookies in your browser.</FlexRow>
+    </div>
+  );
+});

--- a/apps/web/components/Gw2Api/Gw2AccountTableCells.tsx
+++ b/apps/web/components/Gw2Api/Gw2AccountTableCells.tsx
@@ -5,6 +5,8 @@ import { cloneElement, type FC, type ReactElement } from 'react';
 import { useGw2Accounts } from './use-gw2-accounts';
 import { Gw2AccountName } from './Gw2AccountName';
 import { Table } from '@gw2treasures/ui/components/Table/Table';
+import { Skeleton } from '../Skeleton/Skeleton';
+import { withSuspense } from '@/lib/with-suspense';
 
 export interface Gw2AccountHeaderCellsProps {
   requiredScopes: Scope[],
@@ -12,7 +14,7 @@ export interface Gw2AccountHeaderCellsProps {
   colSpan?: number;
 }
 
-export const Gw2AccountHeaderCells: FC<Gw2AccountHeaderCellsProps> = ({ requiredScopes, small, colSpan }) => {
+export const Gw2AccountHeaderCells: FC<Gw2AccountHeaderCellsProps> = withSuspense(({ requiredScopes, small, colSpan }) => {
   const accounts = useGw2Accounts(requiredScopes);
 
   return !accounts.loading && !accounts.error && accounts.accounts.map((account) => (
@@ -22,17 +24,17 @@ export const Gw2AccountHeaderCells: FC<Gw2AccountHeaderCellsProps> = ({ required
       </div>
     </Table.HeaderCell>
   ));
-};
+}, <Table.HeaderCell><Skeleton/></Table.HeaderCell>);
 
 export interface Gw2AccountBodyCells {
   requiredScopes: Scope[],
   children: ReactElement<{ accountId: string }>
 }
 
-export const Gw2AccountBodyCells: FC<Gw2AccountBodyCells> = ({ children, requiredScopes }) => {
+export const Gw2AccountBodyCells: FC<Gw2AccountBodyCells> = withSuspense(({ children, requiredScopes }) => {
   const accounts = useGw2Accounts(requiredScopes);
 
   return !accounts.loading && !accounts.error && accounts.accounts.map((account) => (
     cloneElement(children, { accountId: account.id, key: account.id })
   ));
-};
+}, <td>Loading...</td>);

--- a/apps/web/components/Gw2Api/Gw2Accounts.tsx
+++ b/apps/web/components/Gw2Api/Gw2Accounts.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FC, ReactElement, ReactNode } from 'react';
+import { Suspense, type FC, type ReactElement, type ReactNode } from 'react';
 import type { Gw2Account } from './types';
 import type { Scope } from '@gw2me/client';
 import { useGw2Accounts } from './use-gw2-accounts';
@@ -19,15 +19,23 @@ export interface Gw2AccountsProps {
   authorizationMessage?: ReactNode;
 }
 
-export const Gw2Accounts: FC<Gw2AccountsProps> = ({ children, requiredScopes, optionalScopes = [], options, loading, authorizationMessage }) => {
+export const Gw2Accounts: FC<Gw2AccountsProps> = ({ loading, ...props }) => {
+  return (
+    <Suspense fallback={loading !== undefined ? loading : <Skeleton/>}>
+      <Gw2AccountsInternal loading={loading} {...props}/>
+    </Suspense>
+  );
+};
+
+const Gw2AccountsInternal: FC<Gw2AccountsProps> = ({ children, requiredScopes, optionalScopes = [], options, loading, authorizationMessage }) => {
   const user = useUser();
   const accounts = useGw2Accounts(requiredScopes, optionalScopes, options);
 
-  if(user.loading || accounts.loading) {
+  if(accounts.loading) {
     return loading !== undefined ? loading : (<Skeleton/>);
   }
 
-  if(!user.user) {
+  if(!user) {
     return (
       <Gw2AccountLoginNotice requiredScopes={requiredScopes} optionalScopes={optionalScopes}>
         {authorizationMessage}

--- a/apps/web/components/Gw2Api/use-gw2-accounts.ts
+++ b/apps/web/components/Gw2Api/use-gw2-accounts.ts
@@ -2,7 +2,6 @@ import { useContext, useEffect, useMemo, useState } from 'react';
 import { Gw2ApiContext, type GetAccountsOptions } from './Gw2ApiContext';
 import { type Gw2AccountWithHidden } from './types';
 import { Scope } from '@gw2me/client';
-import { useUser } from '../User/use-user';
 
 type UseGw2AccountsResult =
   | { loading: true }
@@ -16,22 +15,16 @@ const defaultOptions: GetAccountsOptions = {};
 // TODO: when using `useGw2Accounts([])`, this will fetch accounts in an infinite loop,
 //       because we are passing a new array every time. This should be fixed in this hook.
 export function useGw2Accounts(requiredScopes: Scope[], optionalScopes: Scope[] = defaultOptionalScopes, options: GetAccountsOptions = defaultOptions): UseGw2AccountsResult {
-  const user = useUser();
   const [accounts, setAccounts] = useState<Gw2AccountWithHidden[]>(loading);
   const { getAccounts, scopes } = useContext(Gw2ApiContext);
 
   useEffect(() => {
-    // wait until the user is loaded
-    if(user.loading) {
-      return;
-    }
-
     // always require at least `accounts` scope
     const scopes = Array.from(new Set([Scope.Accounts, ...requiredScopes]));
 
     // get accounts
     getAccounts(scopes, optionalScopes, options).then(setAccounts);
-  }, [getAccounts, optionalScopes, options, requiredScopes, user.loading]);
+  }, [getAccounts, optionalScopes, options, requiredScopes]);
 
   return useMemo<UseGw2AccountsResult>(() => {
     if(accounts === loading) {

--- a/apps/web/components/ItemTable/ItemTableColumnsButton.client.tsx
+++ b/apps/web/components/ItemTable/ItemTableColumnsButton.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FC } from 'react';
+import { Suspense, type FC } from 'react';
 import { DropDown } from '@gw2treasures/ui/components/DropDown/DropDown';
 import { Button } from '@gw2treasures/ui/components/Form/Button';
 import { Checkbox } from '@gw2treasures/ui/components/Form/Checkbox';
@@ -10,13 +10,13 @@ import { useItemTableContext } from './context';
 import { Icon } from '@gw2treasures/ui';
 import { useUser } from '../User/use-user';
 import type { TranslationSubset } from '@/lib/translate';
+import { Skeleton } from '../Skeleton/Skeleton';
 
 export interface ItemTableColumnsButtonProps {
   translations: TranslationSubset<'table.columns' | 'table.columns.reset'>
 }
 
 export const ItemTableColumnsButton: FC<ItemTableColumnsButtonProps> = ({ translations }) => {
-  const { user } = useUser();
   const { availableColumns, selectedColumns, defaultColumns, setSelectedColumns } = useItemTableContext();
   const columns = selectedColumns ?? defaultColumns;
 
@@ -25,12 +25,9 @@ export const ItemTableColumnsButton: FC<ItemTableColumnsButtonProps> = ({ transl
   return (
     <DropDown button={<Button icon="columns">{translations['table.columns']}</Button>} preferredPlacement="right-start">
       <MenuList>
-        {!user && (
-          <div style={{ display: 'flex', gap: 12, padding: '4px 16px', maxWidth: 200, alignItems: 'center', background: 'var(--color-background-light)', border: '1px solid var(--color-border-dark)', lineHeight: 1.5, marginBottom: 8, borderRadius: 2 }}>
-            <Icon icon="cookie"/>
-            Changing columns will store cookies in your browser
-          </div>
-        )}
+        <Suspense fallback={<Skeleton/>}>
+          <ItemTableColumnsButtonCookieNotice/>
+        </Suspense>
         {values.map((column) => (
           <Checkbox key={column.id} checked={columns.includes(column.id)} onChange={(checked) => setSelectedColumns(values.filter(({ id }) => id !== column.id ? columns.includes(id) : checked).map(({ id }) => id))}>{column.title}</Checkbox>
         ))}
@@ -38,5 +35,16 @@ export const ItemTableColumnsButton: FC<ItemTableColumnsButtonProps> = ({ transl
         <Button appearance="menu" onClick={() => setSelectedColumns(undefined)} disabled={selectedColumns === undefined}>{translations['table.columns.reset']}</Button>
       </MenuList>
     </DropDown>
+  );
+};
+
+export const ItemTableColumnsButtonCookieNotice = () => {
+  const user = useUser();
+
+  return !user && (
+    <div style={{ display: 'flex', gap: 12, padding: '4px 16px', maxWidth: 200, alignItems: 'center', background: 'var(--color-background-light)', border: '1px solid var(--color-border-dark)', lineHeight: 1.5, marginBottom: 8, borderRadius: 2 }}>
+      <Icon icon="cookie"/>
+      Changing columns will store cookies in your browser
+    </div>
   );
 };

--- a/apps/web/components/User/CookieNotification.tsx
+++ b/apps/web/components/User/CookieNotification.tsx
@@ -1,9 +1,9 @@
-import type { FC } from 'react';
 import { useUser } from './use-user';
 import { Icon } from '@gw2treasures/ui';
+import { withSuspense } from '@/lib/with-suspense';
 
-export const CookieNotification: FC = () => {
-  const { user } = useUser();
+export const CookieNotification = withSuspense(() => {
+  const user = useUser();
 
   if(user) {
     return;
@@ -15,4 +15,4 @@ export const CookieNotification: FC = () => {
       Changing settings will store cookies in your browser
     </div>
   );
-};
+});

--- a/apps/web/components/User/UserProvider.client.tsx
+++ b/apps/web/components/User/UserProvider.client.tsx
@@ -1,30 +1,18 @@
 'use client';
 
-import { useState, type FC, type ReactNode, use, useEffect } from 'react';
-import { SetUserContext, UserContext } from './context';
+import { type FC, type ReactNode } from 'react';
+import { UserContext } from './context';
+import type { SessionUser } from '@/lib/getUser';
 
 interface UserProviderProps {
-  children: ReactNode;
+  children: ReactNode,
+  user: Promise<SessionUser | undefined>
 }
 
-export const UserProvider: FC<UserProviderProps> = ({ children }) => {
-  const [user, setUser] = useState<UserContext>({ user: undefined, loading: true });
-
+export const UserProvider: FC<UserProviderProps> = ({ children, user }) => {
   return (
     <UserContext.Provider value={user}>
-      <SetUserContext.Provider value={setUser}>
-        {children}
-      </SetUserContext.Provider>
+      {children}
     </UserContext.Provider>
   );
-};
-
-export const UserSetter: FC<{ context: UserContext }> = ({ context }) => {
-  const setContext = use(SetUserContext);
-
-  useEffect(() => {
-    setContext(context);
-  }, [context, setContext]);
-
-  return null;
 };

--- a/apps/web/components/User/UserProvider.tsx
+++ b/apps/web/components/User/UserProvider.tsx
@@ -1,5 +1,5 @@
-import { Suspense, type FC, type ReactNode } from 'react';
-import { UserProvider as UserProviderClient, UserSetter } from './UserProvider.client';
+import { type FC, type ReactNode } from 'react';
+import { UserProvider as UserProviderClient } from './UserProvider.client';
 import { getUser } from '@/lib/getUser';
 
 interface UserProviderProps {
@@ -9,15 +9,8 @@ interface UserProviderProps {
 /** Load user (async suspended) and provide it to a global context to be consumed with `useUser()` */
 export const UserProvider: FC<UserProviderProps> = ({ children }) => {
   return (
-    <UserProviderClient>
-      <Suspense><UserLoader/></Suspense>
+    <UserProviderClient user={getUser()}>
       {children}
     </UserProviderClient>
   );
-};
-
-const UserLoader: FC = async () => {
-  const user = await getUser();
-
-  return <UserSetter context={{ user, loading: false }}/>;
 };

--- a/apps/web/components/User/context.ts
+++ b/apps/web/components/User/context.ts
@@ -1,10 +1,8 @@
 import type { SessionUser } from '@/lib/getUser';
 import { createContext } from 'react';
 
-export interface UserContext {
-  user: SessionUser | undefined;
-  loading: boolean;
-}
+export type UserContext = Promise<SessionUser | undefined>;
 
-export const UserContext = createContext<UserContext>({ user: undefined, loading: true });
-export const SetUserContext = createContext<(context: UserContext) => void>(() => {});
+const infinitePromise = new Promise<undefined>(() => {});
+
+export const UserContext = createContext<UserContext>(infinitePromise);

--- a/apps/web/components/User/use-user.ts
+++ b/apps/web/components/User/use-user.ts
@@ -2,5 +2,9 @@ import { use } from 'react';
 import { UserContext } from './context';
 
 export function useUser() {
+  return use(useUserPromise());
+}
+
+export function useUserPromise() {
   return use(UserContext);
 }

--- a/apps/web/lib/with-suspense.tsx
+++ b/apps/web/lib/with-suspense.tsx
@@ -1,0 +1,13 @@
+import { createElement, Suspense, type FC, type ReactNode } from 'react';
+
+export function withSuspense<T extends object>(component: FC<T>, fallback?: ReactNode): FC<T> {
+  const wrapped: FC<T> = (props: T) => (
+    <Suspense fallback={fallback}>
+      {createElement(component, props)}
+    </Suspense>
+  );
+
+  wrapped.displayName = `withSuspense(${component.displayName ?? ''})`;
+
+  return wrapped;
+}

--- a/packages/ui/components/Table/DataTable.tsx
+++ b/packages/ui/components/Table/DataTable.tsx
@@ -1,5 +1,5 @@
 import { Table, type HeaderCellProps } from './Table';
-import { Fragment, type FC, type Key, type ReactElement, type ReactNode } from 'react';
+import { Fragment, Suspense, type FC, type Key, type ReactElement, type ReactNode } from 'react';
 import 'server-only';
 import { DataTableClient, DataTableClientCell, DataTableClientColumn, DataTableClientColumnSelection, DataTableClientRows } from './DataTable.client';
 import { isDefined } from '@gw2treasures/helper/is';
@@ -101,7 +101,7 @@ export function createDataTable<T>(rows: T[], getRowKey: (row: T, index: number)
                     {column.props.title}
                   </DataTableClientColumn>
                 ) : (
-                  <Fragment key={column.key}>{column.props.headers}</Fragment>
+                  <Suspense key={column.key}>{column.props.headers}</Suspense>
                 ))}
               </tr>
             </thead>
@@ -117,9 +117,9 @@ export function createDataTable<T>(rows: T[], getRowKey: (row: T, index: number)
                           {column.props.children(row, index)}
                         </DataTableClientCell>
                       ) : (
-                        <Fragment key={column.key}>
+                        <Suspense key={column.key}>
                           {column.props.children(row, index)}
-                        </Fragment>
+                        </Suspense>
                       ))}
                     </Row>
                   );


### PR DESCRIPTION
This changes the return type of the `useUser` hook from `{ loading: true } | { loading: false, user: User | undefined }` to a promise (`Promise<User | undefined>`), which has to be consumed by `use`.

To prevent the whole page from switching to suspended, a few `Suspense` had to be added.