### PR TITLE
Fix `AbortError` handling in `createAbortableFetch`

### DIFF
--- a/apps/web/lib/useFetch.ts
+++ b/apps/web/lib/useFetch.ts
@@ -44,10 +44,6 @@ export function createAbortableFetch(url: string) {
     }
 
     throw new Error(`Request failed: ${url}`);
-  }).catch((error) => {
-    if(error.name !== 'AbortError') {
-      throw error;
-    }
   });
 
   return { promise, abort: () => { abortController.abort(); } };


### PR DESCRIPTION
We should not catch `AbortError` in `createAbortableFetch`, because otherwise the Promise resolves to `undefined`, which causes more errors down the line.