### PR TITLE
Remove use of `forwardRef`

### DIFF
--- a/apps/web/components/Format/FormatNumber.tsx
+++ b/apps/web/components/Format/FormatNumber.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { forwardRef } from 'react';
+import type { FC } from 'react';
 import { useFormatContext } from './FormatContext';
 import styles from './Format.module.css';
 import { cx } from '@gw2treasures/ui';
+import type { RefProp } from '@gw2treasures/ui/lib/react';
 
 const NARROW_NO_BREAK_SPACE = '\u{202F}';
 
-interface FormatNumberProps {
+interface FormatNumberProps extends RefProp<HTMLDataElement> {
   value: number | bigint | undefined | null;
   className?: string;
   unit?: string;
@@ -15,7 +16,7 @@ interface FormatNumberProps {
 
 const format = new Intl.NumberFormat(undefined, { useGrouping: true });
 
-export const FormatNumber = forwardRef<HTMLDataElement, FormatNumberProps>(({ value, className, unit }: FormatNumberProps, ref) => {
+export const FormatNumber: FC<FormatNumberProps> = ({ ref, value, className, unit }) => {
   const { numberFormat } = useFormatContext();
 
   return (
@@ -24,9 +25,7 @@ export const FormatNumber = forwardRef<HTMLDataElement, FormatNumberProps>(({ va
       {unit && `${NARROW_NO_BREAK_SPACE}${unit}`}
     </data>
   );
-});
-
-FormatNumber.displayName = 'FormatNumber';
+};
 
 export function formatNumber(value: number): string {
   return format.format(value);

--- a/apps/web/components/Link/EntityLink.tsx
+++ b/apps/web/components/Link/EntityLink.tsx
@@ -1,4 +1,4 @@
-import { type AnchorHTMLAttributes, forwardRef, type ReactElement } from 'react';
+import { type AnchorHTMLAttributes, type FC, type ReactElement } from 'react';
 import type { Language, Rarity } from '@gw2treasures/database';
 import type { IconSize } from '@/lib/getIconUrl';
 import type { LocalizedEntity } from '@/lib/localizedName';
@@ -6,8 +6,9 @@ import type { WithIcon } from '@/lib/with';
 import { EntityLinkInternal } from './EntityLinkInternal';
 import { getLinkProperties } from '@/lib/linkProperties';
 import type { EntityIconType } from '../Entity/EntityIcon';
+import type { RefProp } from '@gw2treasures/ui/lib/react';
 
-interface CustomEntityLinkProps {
+interface CustomEntityLinkProps extends RefProp<HTMLAnchorElement> {
   href: string;
   entity: WithIcon<LocalizedEntity> & ({ id: unknown, rarity: Rarity } | { id: unknown });
   icon?: IconSize | 'none' | ReactElement;
@@ -18,10 +19,10 @@ interface CustomEntityLinkProps {
 
 export type EntityLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof CustomEntityLinkProps> & CustomEntityLinkProps;
 
-export const EntityLink = forwardRef<HTMLAnchorElement, EntityLinkProps>(function EntityLink({ entity, ...props }: EntityLinkProps, ref) {
+export const EntityLink: FC<CustomEntityLinkProps> = ({ ref, entity, ...props }) => {
   const cleanEntity = getLinkProperties(entity);
 
   return (
     <EntityLinkInternal ref={ref} entity={cleanEntity} {...props}/>
   );
-});
+};

--- a/apps/web/components/Link/EntityLinkInternal.tsx
+++ b/apps/web/components/Link/EntityLinkInternal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import NextLink from 'next/link';
-import { forwardRef } from 'react';
+import type { FC } from 'react';
 import { EntityIcon } from '../Entity/EntityIcon';
 import styles from './EntityLink.module.css';
 import rarityClasses from '../Layout/RarityColor.module.css';
@@ -12,7 +12,7 @@ import { localizedUrl } from '@/lib/localizedUrl';
 import { cx } from '@gw2treasures/ui';
 import { EntityIconMissing } from '../Entity/EntityIconMissing';
 
-export const EntityLinkInternal = forwardRef<HTMLAnchorElement, EntityLinkProps>(function EntityLinkInternal({ href, entity, icon = 32, language, iconType, ...props }: EntityLinkProps, ref) {
+export const EntityLinkInternal: FC<EntityLinkProps> = ({ ref, href, entity, icon = 32, language, iconType, ...props }) => {
   const defaultLanguage = useLanguage();
 
   if(language && defaultLanguage !== language) {
@@ -36,4 +36,4 @@ export const EntityLinkInternal = forwardRef<HTMLAnchorElement, EntityLinkProps>
       </>
     </NextLink>
   );
-});
+};

--- a/apps/web/components/Reload/ReloadCheckbox.tsx
+++ b/apps/web/components/Reload/ReloadCheckbox.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { forwardRef, useState } from 'react';
+import { useState, type FC } from 'react';
 import { Reload, type ReloadProps } from './Reload';
 import { Checkbox } from '@gw2treasures/ui/components/Form/Checkbox';
+import type { RefProp } from '@gw2treasures/ui/lib/react';
 
-export const ReloadCheckbox = forwardRef<HTMLLabelElement, ReloadProps>(({ ...reloadProps }, ref) => {
+export const ReloadCheckbox: FC<ReloadProps & RefProp<HTMLLabelElement>> = ({ ref, ...reloadProps }) => {
   const [autoRefresh, setAutoRefresh] = useState(false);
 
   return (
@@ -15,6 +16,4 @@ export const ReloadCheckbox = forwardRef<HTMLLabelElement, ReloadProps>(({ ...re
       </Checkbox>
     </>
   );
-});
-
-ReloadCheckbox.displayName = 'ReloadCheckbox';
+};

--- a/packages/ui/components/Form/Button.tsx
+++ b/packages/ui/components/Form/Button.tsx
@@ -1,8 +1,9 @@
 import { cx } from '../../lib/classNames';
 import Link from 'next/link';
-import { forwardRef, type ButtonHTMLAttributes, type HTMLAttributes, type MouseEventHandler, type ReactNode } from 'react';
+import { type ButtonHTMLAttributes, type FC, type HTMLAttributes, type MouseEventHandler, type ReactNode } from 'react';
 import styles from './Button.module.css';
 import { type IconProp, Icon, type IconColor } from '../../icons';
+import type { RefProp } from '../../lib/react';
 
 export interface CommonButtonProps extends Pick<HTMLAttributes<HTMLElement>, 'aria-label' | 'className'> {
   children?: ReactNode;
@@ -14,21 +15,21 @@ export interface CommonButtonProps extends Pick<HTMLAttributes<HTMLElement>, 'ar
   iconOnly?: boolean;
 }
 
-export interface ButtonProps extends CommonButtonProps, Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'disabled' | 'form' | 'name' | 'value' | 'formAction' | 'aria-label'> {
+export interface ButtonProps extends CommonButtonProps, RefProp<HTMLButtonElement>, Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'disabled' | 'form' | 'name' | 'value' | 'formAction' | 'aria-label'> {
   type?: 'button' | 'submit'
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button({ children, icon, iconColor, appearance = 'secondary', flex, intent, iconOnly, onClick, className, type = 'button', ...props }, ref) {
+export const Button: FC<ButtonProps> = ({ ref, children, icon, iconColor, appearance = 'secondary', flex, intent, iconOnly, onClick, className, type = 'button', ...props }) => {
   return (
     <button ref={ref} onClick={onClick} className={cx(styles[appearance], iconOnly && styles.iconOnly, flex && styles.flex, intent && styles[intent], className)} type={type} {...props}>
       {icon && <Icon icon={icon} color={iconColor}/>}
       {children && <span>{children}</span>}
     </button>
   );
-});
+};
 
-export interface LinkButtonProps extends CommonButtonProps {
+export interface LinkButtonProps extends CommonButtonProps, RefProp<HTMLAnchorElement>, Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'target' | 'rel'> {
   onClick?: MouseEventHandler<HTMLAnchorElement>;
   href: string;
   locale?: string | false;
@@ -36,7 +37,7 @@ export interface LinkButtonProps extends CommonButtonProps {
   external?: boolean;
 }
 
-export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps & Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'target' | 'rel'>>(function Button({ children, icon, iconColor, appearance = 'secondary', flex, intent, iconOnly, className, external, ...props }, ref) {
+export const LinkButton: FC<LinkButtonProps> = ({ ref, children, icon, iconColor, appearance = 'secondary', flex, intent, iconOnly, className, external, ...props }) => {
   const LinkElement = external ? 'a' : Link;
 
   return (
@@ -45,4 +46,4 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps & Pick<R
       <span>{children}</span>
     </LinkElement>
   );
-});
+};

--- a/packages/ui/components/Form/Buttons/CopyButton.tsx
+++ b/packages/ui/components/Form/Buttons/CopyButton.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { type FC, forwardRef, useCallback, useEffect, useState } from 'react';
+import { type FC, useCallback, useEffect, useState } from 'react';
 import { Button, type ButtonProps } from '../Button';
 
 export interface CopyButtonProps extends Omit<ButtonProps, 'onClick'> {
   copy: string;
 }
 
-export const CopyButton: FC<CopyButtonProps> = forwardRef<HTMLButtonElement, CopyButtonProps>(function CopyButton ({ copy, ...props }, ref) {
+export const CopyButton: FC<CopyButtonProps> = ({ ref, copy, ...props }) => {
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
@@ -33,4 +33,4 @@ export const CopyButton: FC<CopyButtonProps> = forwardRef<HTMLButtonElement, Cop
   return (
     <Button onClick={handleCopy} {...props} {...overrideProps} ref={ref}/>
   );
-});
+};

--- a/packages/ui/components/Form/Checkbox.tsx
+++ b/packages/ui/components/Form/Checkbox.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { Icon } from '../../icons';
-import { type KeyboardEventHandler, type ReactNode, forwardRef, useCallback, useEffect, useId, useRef } from 'react';
+import { type FC, type KeyboardEventHandler, type ReactNode, useCallback, useEffect, useId, useRef } from 'react';
 import styles from './Checkbox.module.css';
+import type { RefProp } from '../../lib/react';
 
-export interface CheckboxProps {
+export interface CheckboxProps extends RefProp<HTMLLabelElement> {
   checked?: boolean;
   defaultChecked?: boolean;
   formValue?: string;
@@ -15,7 +16,7 @@ export interface CheckboxProps {
   disabled?: boolean;
 }
 
-export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(({ checked, defaultChecked, formValue, indeterminate = false, onChange, name, disabled, children }, ref) => {
+export const Checkbox: FC<CheckboxProps> = ({ ref, checked, defaultChecked, formValue, indeterminate = false, onChange, name, disabled, children }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const id = useId();
 
@@ -41,6 +42,4 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(({ checked, 
       </div>
     </label>
   );
-});
-
-Checkbox.displayName = 'Checkbox';
+};

--- a/packages/ui/components/Notice/Notice.tsx
+++ b/packages/ui/components/Notice/Notice.tsx
@@ -1,10 +1,11 @@
-import { type ReactNode, forwardRef } from 'react';
+import { type FC, type ReactNode } from 'react';
 import styles from './Notice.module.css';
 import { type IconName } from '@gw2treasures/icons';
 import { cx } from '../../lib';
 import { Icon } from '../../icons';
+import type { RefProp } from '../../lib/react';
 
-export interface NoticeProps {
+export interface NoticeProps extends RefProp<HTMLDivElement> {
   children: ReactNode;
   type?: 'info' | 'warning' | 'error';
   icon?: IconName;
@@ -13,11 +14,11 @@ export interface NoticeProps {
   index?: boolean;
 }
 
-export const Notice = forwardRef<HTMLDivElement, NoticeProps>(function Notice({ children, type = 'info', icon, index }, ref) {
+export const Notice: FC<NoticeProps> = ({ ref, children, type = 'info', icon, index }) => {
   return (
     <div className={cx(styles.notice, styles[type])} ref={ref} data-nosnippet={index === false ? true : undefined}>
       {icon && <Icon icon={icon} className={styles.icon}/>}
       <div className={styles.content}>{children}</div>
     </div>
   );
-});
+};

--- a/packages/ui/icons/Icon.tsx
+++ b/packages/ui/icons/Icon.tsx
@@ -1,16 +1,17 @@
-import { cloneElement, forwardRef, type FunctionComponent } from 'react';
+import { cloneElement, type FC } from 'react';
 import { getIcon, type IconColor, type IconProp } from './index';
 import styles from './Icon.module.css';
 import { cx } from '../lib';
+import type { RefProp } from '../lib/react';
 
-export interface IconProps {
+export interface IconProps extends RefProp {
   icon: IconProp,
   color?: IconColor,
   className?: string,
 }
 
-export const Icon: FunctionComponent<IconProps> = forwardRef(function Icon({ icon, color, className }, ref) {
+export const Icon: FC<IconProps> = ({ ref, icon, color, className }) => {
   const c = getIcon(icon);
 
   return c ? cloneElement(c, { className: cx(styles.icon, className), style: { '--icon-color': color }, ref }) : null;
-});
+};

--- a/packages/ui/icons/IconSprite.tsx
+++ b/packages/ui/icons/IconSprite.tsx
@@ -1,9 +1,9 @@
-import { forwardRef, type SVGAttributes } from 'react';
+import { type FC, type SVGAttributes } from 'react';
 import type { IconName } from '@gw2treasures/icons';
-import reactDOM from 'react-dom';
 import styles from './IconSprite.module.css';
+import type { RefProp } from '../lib/react';
 
-export interface IconSpriteProps extends SVGAttributes<SVGSVGElement> {
+export interface IconSpriteProps extends SVGAttributes<SVGSVGElement>, RefProp<SVGSVGElement> {
   icon: IconName,
 }
 
@@ -11,16 +11,13 @@ export interface IconSpriteProps extends SVGAttributes<SVGSVGElement> {
 // and is not compatible with just webpack used outside of Next.js (i.e. gw2.me extensions)
 const sprite = new URL('@gw2treasures/icons/sprite.svg', import.meta.url).toString();
 
-export const IconSprite = forwardRef<SVGSVGElement, IconSpriteProps>(function IconSprite({ icon, ...props }, ref) {
-  // preload in react@canary (has preload), react@18 has no preload
-  // TODO: remove once using react@beta or react@19
-  if('preload' in reactDOM && typeof reactDOM.preload === 'function') {
-    reactDOM.preload(sprite, { as: 'image' });
-  }
+export const IconSprite: FC<IconSpriteProps> = ({ ref, icon, ...props }) => {
+  // TODO: preloading sprites is not possible in browsers yet (see https://github.com/whatwg/fetch/issues/1012)
+  // reactDOM.preload(sprite, { as: 'image' });
 
   return (
     <svg ref={ref} viewBox="0 0 16 16" {...props}>
       <use href={`${sprite}#${icon}`} className={styles[icon]}/>
     </svg>
   );
-});
+};

--- a/packages/ui/lib/react.ts
+++ b/packages/ui/lib/react.ts
@@ -1,0 +1,5 @@
+import type { Ref } from 'react';
+
+export interface RefProp<T = Element> {
+  ref?: Ref<T>
+}


### PR DESCRIPTION
React 19 does not require `forwardRef` anymore (see https://react.dev/blog/2024/04/25/react-19#ref-as-a-prop)