### PR TITLE
Allow job "Docker (arm64) / Build: web" to fail for PRs and merge queue

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         target: [ web, worker, legacy-importer, database-migration, e2e ]
+    continue-on-error: ${{ matrix.target == 'web' && inputs.platform == 'arm64' && github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This job keeps failing because google fonts times out, so lets just allow this unless its a push to main. We catch all real errors in the amd64 build, which for some reason always works. We need the arm64 build to succeed on main, because thats the actual architecture of the production environment.