### PR TITLE
Fix new skins not connecting to achievement bits and items

### DIFF
--- a/apps/worker/src/jobs/skins/rediscovered.ts
+++ b/apps/worker/src/jobs/skins/rediscovered.ts
@@ -34,6 +34,7 @@ export const SkinsRediscovered: Job = {
         name_es: data.es.name,
         name_fr: data.fr.name,
         iconId,
+        version: 0,
         lastCheckedAt: new Date(),
         history: { createMany: { data: [] }}
       };


### PR DESCRIPTION
If an achievement gets added that has `skin` bits or an item that unlocks a skin, but the skin does not exist in the db yet, once the skin gets added it would not connect to `achievementBits` or `unlockedByItems`. Ideally this should just run for new skins, but since there are missing connections already, we have to do this migration for all skins.