### PR TITLE
Expose achievement revisions in UI

### DIFF
--- a/apps/web/app/[language]/achievement/[id]/[revisionId]/page.tsx
+++ b/apps/web/app/[language]/achievement/[id]/[revisionId]/page.tsx
@@ -1,0 +1,47 @@
+import { AchievementPageComponent } from '../component';
+import type { Metadata } from 'next';
+import { getRevision } from '../data';
+import { notFound } from 'next/navigation';
+import type { PageProps } from '@/lib/next';
+import { strip } from 'gw2-tooltip-html';
+import { parseIcon } from '@/lib/parseIcon';
+import { getIconUrl } from '@/lib/getIconUrl';
+import { getAlternateUrls } from '@/lib/url';
+
+type AchievementRevisionPageProps = PageProps<{ id: string, revisionId: string }>;
+
+export default async function AchievementPage({ params }: AchievementRevisionPageProps) {
+  const { language, id, revisionId } = await params;
+  const achievementId = Number(id);
+
+  return <AchievementPageComponent language={language} achievementId={achievementId} revisionId={revisionId}/>;
+}
+
+export async function generateMetadata({ params }: AchievementRevisionPageProps): Promise<Metadata> {
+  const { language, id: idParam, revisionId } = await params;
+  const achievementId = Number(idParam);
+
+  const { data } = await getRevision(achievementId, language, revisionId);
+
+  if(!data) {
+    notFound();
+  }
+
+  const description = [
+    strip(data.description),
+    data.requirement && strip(data.requirement.replace(/( |^)\/?( |$)/g, `$1${data.tiers[data.tiers.length - 1].count}$2`))
+  ].filter(Boolean).join('\n\n');
+
+  const icon = parseIcon(data.icon);
+
+  return {
+    title: `${data.name} @ ${revisionId}`,
+    description,
+    openGraph: {
+      images: icon ? [{ url: getIconUrl(icon, 64), width: 64, height: 64, type: 'image/png' }] : []
+    },
+    twitter: { card: 'summary' },
+    alternates: getAlternateUrls(`/achievement/${achievementId}/${revisionId}`, language),
+    robots: { index: false }
+  };
+}

--- a/apps/web/app/[language]/achievement/[id]/component.tsx
+++ b/apps/web/app/[language]/achievement/[id]/component.tsx
@@ -1,0 +1,334 @@
+/* eslint-disable react/no-array-index-key */
+import type { Language } from '@gw2treasures/database';
+import DetailLayout from '@/components/Layout/DetailLayout';
+import { db } from '@/lib/prisma';
+import { localizedName } from '@/lib/localizedName';
+import { Headline } from '@gw2treasures/ui/components/Headline/Headline';
+import { Json } from '@/components/Format/Json';
+import { Icon } from '@gw2treasures/ui';
+import { format } from 'gw2-tooltip-html';
+import { notFound } from 'next/navigation';
+import styles from './page.module.css';
+import { Coins } from '@/components/Format/Coins';
+import { ItemList } from '@/components/ItemList/ItemList';
+import { getLinkProperties, linkProperties, linkPropertiesWithoutRarity } from '@/lib/linkProperties';
+import { ItemLink } from '@/components/Item/ItemLink';
+import { SkinLink } from '@/components/Skin/SkinLink';
+import { MiniLink } from '@/components/Mini/MiniLink';
+import { AchievementLink } from '@/components/Achievement/AchievementLink';
+import { AchievementInfobox } from '@/components/Achievement/AchievementInfobox';
+import { RemovedFromApiNotice } from '@/components/Notice/RemovedFromApiNotice';
+import { Breadcrumb, BreadcrumbItem } from '@/components/Breadcrumb/Breadcrumb';
+import { AchievementCategoryLink } from '@/components/Achievement/AchievementCategoryLink';
+import { AccountAchievementProgressHeader, AccountAchievementProgressRow } from '@/components/Achievement/AccountAchievementProgress';
+import { TierTable } from './tier-table';
+import { FlexRow } from '@gw2treasures/ui/components/Layout/FlexRow';
+import { createDataTable } from '@gw2treasures/ui/components/Table/DataTable';
+import { ColumnSelect } from '@/components/Table/ColumnSelect';
+import { pageView } from '@/lib/pageView';
+import { cache } from '@/lib/cache';
+import { UnknownItem } from '@/components/Item/UnknownItem';
+import { getTranslate } from '@/lib/translate';
+import type { AchievementFlags } from '@gw2api/types/data/achievement';
+import { AchievementTable } from '@/components/Achievement/AchievementTable';
+import type { ReactNode } from 'react';
+import { Mastery, MasteryColors } from '@/components/Achievement/Mastery';
+import { Table } from '@gw2treasures/ui/components/Table/Table';
+import { FormatDate } from '@/components/Format/FormatDate';
+import { Tip } from '@gw2treasures/ui/components/Tip/Tip';
+import Link from 'next/link';
+import { AchievementLinkTooltip } from '@/components/Achievement/AchievementLinkTooltip';
+import { Tooltip } from '@/components/Tooltip/Tooltip';
+import { getRevision } from './data';
+import { Notice } from '@gw2treasures/ui/components/Notice/Notice';
+
+
+const notPartOfCategoryDisplayFlags: AchievementFlags[] = ['Repeatable', 'RequiresUnlock', 'Hidden', 'Daily', 'Weekly', 'IgnoreNearlyComplete'];
+
+export interface AchievementPageComponentProps {
+  language: Language,
+  achievementId: number,
+  revisionId?: string,
+}
+
+const getAchievement = cache(async (id: number, language: Language, revisionId?: string) => {
+  const [achievement, revision] = await Promise.all([
+    db.achievement.findUnique({
+      where: { id },
+      include: {
+        icon: true,
+        achievementCategory: {
+          select: {
+            ...linkPropertiesWithoutRarity,
+            categoryDisplayId: true,
+            achievementGroup: { select: { id: true, name_de: true, name_en: true, name_es: true, name_fr: true }},
+            categoryDisplay: { select: linkPropertiesWithoutRarity }
+          }
+        },
+        prerequisiteFor: { select: linkPropertiesWithoutRarity },
+        prerequisites: { select: linkPropertiesWithoutRarity },
+        bitsItem: { select: linkProperties },
+        bitsSkin: { select: linkProperties },
+        bitsMini: { select: linkPropertiesWithoutRarity },
+        rewardsItem: { select: linkProperties },
+        rewardsTitle: { select: { id: true, name_de: true, name_en: true, name_es: true, name_fr: true }},
+        history: {
+          include: { revision: { select: { id: true, buildId: true, createdAt: true, description: true, language: true }}},
+          where: { revision: { language }},
+          orderBy: { revision: { createdAt: 'desc' }}
+        },
+      }
+    }),
+    getRevision(id, language, revisionId)
+  ]);
+
+  if(!achievement || !revision.data) {
+    notFound();
+  }
+
+  const categoryAchievements = revision.data.flags.includes('CategoryDisplay')
+    ? await db.achievement.findMany({
+        where: {
+          achievementCategoryId: achievement.achievementCategoryId,
+          id: { not: achievement.id },
+          historic: false,
+          NOT: { flags: { hasSome: notPartOfCategoryDisplayFlags }}
+        },
+        include: {
+          icon: true,
+          rewardsItem: { select: linkProperties },
+          rewardsTitle: { select: { id: true, name_de: true, name_en: true, name_es: true, name_fr: true }}
+        }
+      })
+    : [];
+
+  return { achievement, revision, categoryAchievements };
+}, ['achievement'], { revalidate: 60 });
+
+export async function AchievementPageComponent({ language, achievementId, revisionId }: AchievementPageComponentProps) {
+  const { achievement, revision: { revision, data }, categoryAchievements } = await getAchievement(achievementId, language, revisionId);
+  await pageView('achievement', achievementId);
+
+  // 404 if item doesn't exist
+  if(!achievement || !revision || !data) {
+    notFound();
+  }
+
+  const fixedRevision = revisionId !== undefined;
+
+  const Bits = data.bits && data.bits.length > 0 && !data.flags.includes('CategoryDisplay') ? createDataTable(data.bits, (_, index) => index) : undefined;
+  const hasCategoryAchievements = data.flags.includes('CategoryDisplay') && categoryAchievements.length > 0;
+  const OptionalCategoryAchievementTable = hasCategoryAchievements ? AchievementTable : ({ children }: { children: (t: ReactNode, c: ReactNode) => ReactNode }) => children(null, null);
+  // const CategoryAchievements = hasCategoryAchievements ? createDataTable(categoryAchievements, (achievement) => achievement.id) : undefined;
+
+  const t = getTranslate(language);
+
+  return (
+    <DetailLayout
+      color={achievement.icon?.color ?? undefined}
+      title={data.name}
+      icon={achievement.icon}
+      breadcrumb={(
+        <Breadcrumb>
+          <BreadcrumbItem href="/achievement" name={t('navigation.achievements')}/>
+          {achievement.achievementCategory?.achievementGroup ? <BreadcrumbItem href={`/achievement#${achievement.achievementCategory.achievementGroup.id}`} name={localizedName(achievement.achievementCategory.achievementGroup, language)}/> : <BreadcrumbItem name="Unknown Group"/>}
+          {achievement.achievementCategory ? <BreadcrumbItem name={localizedName(achievement.achievementCategory, language)} href={`/achievement/category/${achievement.achievementCategoryId}`}><AchievementCategoryLink achievementCategory={achievement.achievementCategory} icon="none"/></BreadcrumbItem> : <BreadcrumbItem name="Unknown Category"/>}
+        </Breadcrumb>
+      )}
+      infobox={<AchievementInfobox achievement={achievement} data={data} language={language}/>}
+    >
+      {achievement[`currentId_${language}`] !== revision.id && (
+        <Notice icon="revision">You are viewing an old revision of this achievement{revision.buildId !== 0 && (<> (<Link href={`/build/${revision.buildId}`}>Build {revision.buildId}</Link>)</>)}. Some data is only available when viewing the latest version. <Link href={`/achievement/${achievement.id}`}>View latest</Link>.</Notice>
+      )}
+      {achievement[`currentId_${language}`] === revision.id && fixedRevision && (
+        <Notice icon="revision">You are viewing this achievement at a fixed revision{revision.buildId !== 0 && (<> (<Link href={`/build/${revision.buildId}`}>Build {revision.buildId}</Link>)</>)}. Some data is only available when viewing the latest version. <Link href={`/achievement/${achievement.id}`}>View latest</Link>.</Notice>
+      )}
+      {!fixedRevision && achievement.removedFromApi && (
+        <RemovedFromApiNotice type="achievement"/>
+      )}
+
+      {data.description && (
+        <p dangerouslySetInnerHTML={{ __html: format(data.description) }}/>
+      )}
+
+      {data.flags.includes('RequiresUnlock') && (
+        <>
+          <Headline id="unlock">Unlock</Headline>
+          <p>{data.locked_text || 'You have to unlock this achievement.'}</p>
+        </>
+      )}
+
+      {achievement.id !== achievement.achievementCategory?.categoryDisplayId && achievement.achievementCategory?.categoryDisplay && !data.flags.some((flag) => notPartOfCategoryDisplayFlags.includes(flag as AchievementFlags)) && (
+        <>
+          <Headline id="unlock">Part of</Headline>
+          <AchievementLink achievement={achievement.achievementCategory.categoryDisplay}/>
+        </>
+      )}
+
+      {data.prerequisites && data.prerequisites?.length > 0 && (
+        <>
+          <Headline id="prerequisites">Prerequisites</Headline>
+          <ItemList>
+            {data.prerequisites.map((prerequisiteId) => {
+              const prerequisite = achievement.prerequisites.find(({ id }) => prerequisiteId === id);
+
+              return (
+                <li key={prerequisiteId}>{prerequisite ? <AchievementLink achievement={prerequisite}/> : `Unknown achievement ${prerequisiteId}`}</li>
+              );
+            })}
+          </ItemList>
+        </>
+      )}
+
+      {(data.requirement || (data.bits && data.bits.length > 0) || categoryAchievements.length > 0) && (
+        <OptionalCategoryAchievementTable achievements={categoryAchievements} language={language}>
+          {(categoryAchievementTable, columnSelect) => (
+            <>
+              <Headline id="objectives" actions={(
+                <FlexRow>
+                  {Bits && <ColumnSelect table={Bits}/>}
+                  {columnSelect}
+                </FlexRow>
+              )}
+              >
+                Objectives
+              </Headline>
+              {data.requirement && (
+                <p dangerouslySetInnerHTML={{ __html: format(data.requirement.replace(/( |^)\/?( |$)/g, `$1${data.tiers[data.tiers.length - 1].count}$2`)) }}/>
+              )}
+
+              {Bits && (
+                <Bits.Table>
+                  <Bits.Column id="index" title="Index" small align="right" hidden>{(_, index) => index}</Bits.Column>
+                  <Bits.Column id="type" title="Type" small hidden>{({ type }) => type}</Bits.Column>
+                  <Bits.Column id="objective" title="Objective">
+                    {(bit, index) => {
+                      switch(bit.type) {
+                        case 'Item': {
+                          const item = achievement.bitsItem.find(({ id }) => id === bit.id);
+                          return item ? (<ItemLink item={item}/>) : <UnknownItem id={bit.id}/>;
+                        }
+                        case 'Skin': {
+                          const skin = achievement.bitsSkin.find(({ id }) => id === bit.id);
+                          return skin ? (<SkinLink skin={skin}/>) : `Unknown skin ${bit.id}`;
+                        }
+                        case 'Minipet': {
+                          const mini = achievement.bitsMini.find(({ id }) => id === bit.id);
+                          return mini ? (<MiniLink mini={mini}/>) : `Unknown minipet ${bit.id}`;
+                        }
+                        case 'Text':
+                          return bit.text || `Unknown Objective #${index + 1}`;
+                        default:
+                          return `Unknown Objective #${index + 1}`;
+                      }
+                    }}
+                  </Bits.Column>
+                  {!fixedRevision && (
+                    <Bits.DynamicColumns headers={<AccountAchievementProgressHeader/>}>
+                      {(_, index) => <AccountAchievementProgressRow achievement={achievement} bitId={index}/>}
+                    </Bits.DynamicColumns>
+                  )}
+                </Bits.Table>
+              )}
+
+              {categoryAchievementTable}
+            </>
+          )}
+        </OptionalCategoryAchievementTable>
+      )}
+
+      <Headline id="tiers">Tiers</Headline>
+      <TierTable achievement={data}/>
+
+      {data.rewards && (
+        <>
+          <Headline id="rewards">Rewards</Headline>
+          <ItemList>
+            {data.rewards.map((reward) => {
+              switch(reward.type) {
+                case 'Coins':
+                  return (<li key="coins"><FlexRow><span className={styles.listIcon}><Icon icon="coins"/></span> <Coins value={reward.count!}/></FlexRow></li>);
+                case 'Mastery':
+                  return (
+                    <li key={reward.id}>
+                      <FlexRow>
+                        <span className={styles.listIcon} style={reward.region ? { '--icon-color': MasteryColors[reward.region], backgroundColor: `${MasteryColors[reward.region]}22` } : undefined}><Icon icon="mastery"/></span>
+                        <Mastery mastery={reward.region}/>
+                      </FlexRow>
+                    </li>
+                  );
+                case 'Title': {
+                  const title = achievement.rewardsTitle.find(({ id }) => id === reward.id);
+                  return (
+                    <li key={reward.id}>
+                      <FlexRow>
+                        <span className={styles.listIcon}>
+                          <Icon icon="title"/>
+                        </span>
+                        {title ? <span dangerouslySetInnerHTML={{ __html: format(localizedName(title, language)) }}/> : `Unknown (${reward.id})` }
+                      </FlexRow>
+                    </li>
+                  );
+                }
+                case 'Item': {
+                  const item = achievement.rewardsItem.find(({ id }) => id === reward.id);
+                  return (
+                    <li key={reward.id}>
+                      {item ? (<ItemLink item={item}/>) : <UnknownItem id={reward.id}/>}
+                      {reward.count && reward.count > 1 && (<span>&times;{reward.count}</span>)}
+                    </li>
+                  );
+                }
+              }
+            })}
+          </ItemList>
+        </>
+      )}
+
+      {achievement.prerequisiteFor.length > 0 && (
+        <>
+          <Headline id="prerequisiteFor">Prerequisite For</Headline>
+          <ItemList>
+            {achievement.prerequisiteFor.map((prerequisite) => (
+              <li key={prerequisite.id}><AchievementLink achievement={prerequisite}/></li>
+            ))}
+          </ItemList>
+        </>
+      )}
+
+
+      <Headline id="history">History</Headline>
+      <Table>
+        <thead>
+          <tr>
+            <Table.HeaderCell small/>
+            <Table.HeaderCell small>Build</Table.HeaderCell>
+            <Table.HeaderCell>Description</Table.HeaderCell>
+            <Table.HeaderCell small>Date</Table.HeaderCell>
+            <Table.HeaderCell small>Actions</Table.HeaderCell>
+          </tr>
+        </thead>
+        <tbody>
+          {achievement.history.map((history) => (
+            <tr key={history.revisionId}>
+              <td style={{ paddingRight: 0 }}>{history.revisionId === revision.id && <Tip tip="Currently viewing"><Icon icon="eye"/></Tip>}</td>
+              <td>{history.revision.buildId !== 0 ? (<Link href={`/build/${history.revision.buildId}`}>{history.revision.buildId}</Link>) : '-'}</td>
+              <td>
+                <Tooltip content={<AchievementLinkTooltip achievement={getLinkProperties(achievement)} language={language} revision={history.revisionId}/>}>
+                  <Link href={`/achievement/${achievement.id}/${history.revisionId}`}>
+                    {history.revision.description}
+                  </Link>
+                </Tooltip>
+              </td>
+              <td><FormatDate date={history.revision.createdAt} relative/></td>
+              <td>{history.revisionId !== revision.id && <Link href={`/achievement/${achievement.id}/${history.revisionId}`}>View</Link>}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+
+      <Headline id="data">Data</Headline>
+      <Json data={data}/>
+    </DetailLayout>
+  );
+}

--- a/apps/web/app/[language]/achievement/[id]/component.tsx
+++ b/apps/web/app/[language]/achievement/[id]/component.tsx
@@ -238,7 +238,7 @@ export async function AchievementPageComponent({ language, achievementId, revisi
       )}
 
       <Headline id="tiers">Tiers</Headline>
-      <TierTable achievement={data}/>
+      <TierTable achievement={data} showAccounts={!fixedRevision}/>
 
       {data.rewards && (
         <>

--- a/apps/web/app/[language]/achievement/[id]/data.ts
+++ b/apps/web/app/[language]/achievement/[id]/data.ts
@@ -1,0 +1,16 @@
+import { cache } from '@/lib/cache';
+import { db } from '@/lib/prisma';
+import type { Achievement } from '@gw2api/types/data/achievement';
+import type { Language } from '@gw2treasures/database';
+
+
+export const getRevision = cache(async (id: number, language: Language, revisionId?: string) => {
+  const revision = revisionId
+    ? await db.revision.findUnique({ where: { id: revisionId }})
+    : await db.revision.findFirst({ where: { [`currentAchievement_${language}`]: { id }}});
+
+  return {
+    revision,
+    data: revision ? JSON.parse(revision.data) as Achievement : undefined,
+  };
+}, ['revision-achievement'], { revalidate: 60 });

--- a/apps/web/app/[language]/achievement/[id]/page.tsx
+++ b/apps/web/app/[language]/achievement/[id]/page.tsx
@@ -1,326 +1,47 @@
-/* eslint-disable react/no-array-index-key */
-import type { Language } from '@gw2treasures/database';
-import DetailLayout from '@/components/Layout/DetailLayout';
-import { db } from '@/lib/prisma';
-import type { Gw2Api } from 'gw2-api-types';
-import { localizedName } from '@/lib/localizedName';
-import { Headline } from '@gw2treasures/ui/components/Headline/Headline';
-import { Json } from '@/components/Format/Json';
-import { Icon } from '@gw2treasures/ui';
-import { format, strip } from 'gw2-tooltip-html';
-import { notFound } from 'next/navigation';
-import styles from './page.module.css';
-import { Coins } from '@/components/Format/Coins';
-import { ItemList } from '@/components/ItemList/ItemList';
-import { linkProperties, linkPropertiesWithoutRarity } from '@/lib/linkProperties';
-import { ItemLink } from '@/components/Item/ItemLink';
-import { SkinLink } from '@/components/Skin/SkinLink';
-import { MiniLink } from '@/components/Mini/MiniLink';
-import { AchievementLink } from '@/components/Achievement/AchievementLink';
-import { AchievementInfobox } from '@/components/Achievement/AchievementInfobox';
-import { RemovedFromApiNotice } from '@/components/Notice/RemovedFromApiNotice';
-import { Breadcrumb, BreadcrumbItem } from '@/components/Breadcrumb/Breadcrumb';
-import { AchievementCategoryLink } from '@/components/Achievement/AchievementCategoryLink';
+import { AchievementPageComponent } from './component';
 import type { Metadata } from 'next';
-import { AccountAchievementProgressHeader, AccountAchievementProgressRow } from '@/components/Achievement/AccountAchievementProgress';
-import { TierTable } from './tier-table';
-import { FlexRow } from '@gw2treasures/ui/components/Layout/FlexRow';
-import { createDataTable } from '@gw2treasures/ui/components/Table/DataTable';
-import { ColumnSelect } from '@/components/Table/ColumnSelect';
-import { pageView } from '@/lib/pageView';
-import { cache } from '@/lib/cache';
-import { getAlternateUrls } from '@/lib/url';
-import { UnknownItem } from '@/components/Item/UnknownItem';
-import { getTranslate } from '@/lib/translate';
+import { getRevision } from './data';
+import { notFound } from 'next/navigation';
 import { getIconUrl } from '@/lib/getIconUrl';
-import type { Achievement, AchievementFlags } from '@gw2api/types/data/achievement';
-import { AchievementTable } from '@/components/Achievement/AchievementTable';
-import type { ReactNode } from 'react';
-import { Mastery, MasteryColors } from '@/components/Achievement/Mastery';
+import { parseIcon } from '@/lib/parseIcon';
+import { getAlternateUrls } from '@/lib/url';
 import type { PageProps } from '@/lib/next';
-
-
-const notPartOfCategoryDisplayFlags: AchievementFlags[] = ['Repeatable', 'RequiresUnlock', 'Hidden', 'Daily', 'Weekly', 'IgnoreNearlyComplete'];
+import { strip } from 'gw2-tooltip-html';
 
 export type AchievementPageProps = PageProps<{ id: string }>;
 
-const getAchievement = cache(async (id: number, language: Language) => {
-  const [achievement, revision] = await Promise.all([
-    db.achievement.findUnique({
-      where: { id },
-      include: {
-        icon: true,
-        achievementCategory: {
-          select: {
-            ...linkPropertiesWithoutRarity,
-            categoryDisplayId: true,
-            achievementGroup: { select: { id: true, name_de: true, name_en: true, name_es: true, name_fr: true }},
-            categoryDisplay: { select: linkPropertiesWithoutRarity }
-          }
-        },
-        prerequisiteFor: { select: linkPropertiesWithoutRarity },
-        prerequisites: { select: linkPropertiesWithoutRarity },
-        bitsItem: { select: linkProperties },
-        bitsSkin: { select: linkProperties },
-        bitsMini: { select: linkPropertiesWithoutRarity },
-        rewardsItem: { select: linkProperties },
-        rewardsTitle: { select: { id: true, name_de: true, name_en: true, name_es: true, name_fr: true }}
-      }
-    }),
-    db.revision.findFirst({ where: { [`currentAchievement_${language}`]: { id }}})
-  ]);
-
-  if(!achievement || !revision) {
-    notFound();
-  }
-
-  const data: Gw2Api.Achievement = JSON.parse(revision.data);
-
-  const categoryAchievements = data.flags.includes('CategoryDisplay')
-    ? await db.achievement.findMany({
-        where: {
-          achievementCategoryId: achievement.achievementCategoryId,
-          id: { not: achievement.id },
-          historic: false,
-          NOT: { flags: { hasSome: notPartOfCategoryDisplayFlags }}
-        },
-        include: {
-          icon: true,
-          rewardsItem: { select: linkProperties },
-          rewardsTitle: { select: { id: true, name_de: true, name_en: true, name_es: true, name_fr: true }}
-        }
-      })
-    : [];
-
-  return { achievement, revision, categoryAchievements };
-}, ['achievement'], { revalidate: 60 });
-
-async function AchievementPage({ params }: AchievementPageProps) {
+export default async function AchievementPage({ params }: AchievementPageProps) {
   const { language, id } = await params;
-  const achievementId: number = Number(id);
+  const achievementId = Number(id);
 
-  const { achievement, revision, categoryAchievements } = await getAchievement(achievementId, language);
-  await pageView('achievement', achievementId);
-
-  const data: Achievement = JSON.parse(revision.data);
-
-  const Bits = data.bits && data.bits.length > 0 && !data.flags.includes('CategoryDisplay') ? createDataTable(data.bits, (_, index) => index) : undefined;
-  const hasCategoryAchievements = data.flags.includes('CategoryDisplay') && categoryAchievements.length > 0;
-  const OptionalCategoryAchievementTable = hasCategoryAchievements ? AchievementTable : ({ children }: { children: (t: ReactNode, c: ReactNode) => ReactNode }) => children(null, null);
-  // const CategoryAchievements = hasCategoryAchievements ? createDataTable(categoryAchievements, (achievement) => achievement.id) : undefined;
-
-  const t = getTranslate(language);
-
-  return (
-    <DetailLayout
-      color={achievement.icon?.color ?? undefined}
-      title={data.name}
-      icon={achievement.icon}
-      breadcrumb={(
-        <Breadcrumb>
-          <BreadcrumbItem href="/achievement" name={t('navigation.achievements')}/>
-          {achievement.achievementCategory?.achievementGroup ? <BreadcrumbItem href={`/achievement#${achievement.achievementCategory.achievementGroup.id}`} name={localizedName(achievement.achievementCategory.achievementGroup, language)}/> : <BreadcrumbItem name="Unknown Group"/>}
-          {achievement.achievementCategory ? <BreadcrumbItem name={localizedName(achievement.achievementCategory, language)} href={`/achievement/category/${achievement.achievementCategoryId}`}><AchievementCategoryLink achievementCategory={achievement.achievementCategory} icon="none"/></BreadcrumbItem> : <BreadcrumbItem name="Unknown Category"/>}
-        </Breadcrumb>
-      )}
-      infobox={<AchievementInfobox achievement={achievement} data={data} language={language}/>}
-    >
-      {achievement.removedFromApi && (
-        <RemovedFromApiNotice type="achievement"/>
-      )}
-
-      {data.description && (
-        <p dangerouslySetInnerHTML={{ __html: format(data.description) }}/>
-      )}
-
-      {data.flags.includes('RequiresUnlock') && (
-        <>
-          <Headline id="unlock">Unlock</Headline>
-          <p>{data.locked_text || 'You have to unlock this achievement.'}</p>
-        </>
-      )}
-
-      {achievement.id !== achievement.achievementCategory?.categoryDisplayId && achievement.achievementCategory?.categoryDisplay && !data.flags.some((flag) => notPartOfCategoryDisplayFlags.includes(flag as AchievementFlags)) && (
-        <>
-          <Headline id="unlock">Part of</Headline>
-          <AchievementLink achievement={achievement.achievementCategory.categoryDisplay}/>
-        </>
-      )}
-
-      {data.prerequisites && data.prerequisites?.length > 0 && (
-        <>
-          <Headline id="prerequisites">Prerequisites</Headline>
-          <ItemList>
-            {data.prerequisites.map((prerequisiteId) => {
-              const prerequisite = achievement.prerequisites.find(({ id }) => prerequisiteId === id);
-
-              return (
-                <li key={prerequisiteId}>{prerequisite ? <AchievementLink achievement={prerequisite}/> : `Unknown achievement ${prerequisiteId}`}</li>
-              );
-            })}
-          </ItemList>
-        </>
-      )}
-
-      {(data.requirement || (data.bits && data.bits.length > 0) || categoryAchievements.length > 0) && (
-        <OptionalCategoryAchievementTable achievements={categoryAchievements} language={language}>
-          {(categoryAchievementTable, columnSelect) => (
-            <>
-              <Headline id="objectives" actions={(
-                <FlexRow>
-                  {Bits && <ColumnSelect table={Bits}/>}
-                  {columnSelect}
-                </FlexRow>
-              )}
-              >
-                Objectives
-              </Headline>
-              {data.requirement && (
-                <p dangerouslySetInnerHTML={{ __html: format(data.requirement.replace(/( |^)\/?( |$)/g, `$1${data.tiers[data.tiers.length - 1].count}$2`)) }}/>
-              )}
-
-              {Bits && (
-                <Bits.Table>
-                  <Bits.Column id="index" title="Index" small align="right" hidden>{(_, index) => index}</Bits.Column>
-                  <Bits.Column id="type" title="Type" small hidden>{({ type }) => type}</Bits.Column>
-                  <Bits.Column id="objective" title="Objective">
-                    {(bit, index) => {
-                      switch(bit.type) {
-                        case 'Item': {
-                          const item = achievement.bitsItem.find(({ id }) => id === bit.id);
-                          return item ? (<ItemLink item={item}/>) : <UnknownItem id={bit.id}/>;
-                        }
-                        case 'Skin': {
-                          const skin = achievement.bitsSkin.find(({ id }) => id === bit.id);
-                          return skin ? (<SkinLink skin={skin}/>) : `Unknown skin ${bit.id}`;
-                        }
-                        case 'Minipet': {
-                          const mini = achievement.bitsMini.find(({ id }) => id === bit.id);
-                          return mini ? (<MiniLink mini={mini}/>) : `Unknown minipet ${bit.id}`;
-                        }
-                        case 'Text':
-                          return bit.text || `Unknown Objective #${index + 1}`;
-                        default:
-                          return `Unknown Objective #${index + 1}`;
-                      }
-                    }}
-                  </Bits.Column>
-                  <Bits.DynamicColumns headers={<AccountAchievementProgressHeader/>}>
-                    {(_, index) => <AccountAchievementProgressRow achievement={achievement} bitId={index}/>}
-                  </Bits.DynamicColumns>
-                </Bits.Table>
-              )}
-
-              {categoryAchievementTable}
-            </>
-          )}
-        </OptionalCategoryAchievementTable>
-      )}
-
-      <Headline id="tiers">Tiers</Headline>
-      <TierTable achievement={data}/>
-
-      {data.rewards && (
-        <>
-          <Headline id="rewards">Rewards</Headline>
-          <ItemList>
-            {data.rewards.map((reward) => {
-              switch(reward.type) {
-                case 'Coins':
-                  return (<li key="coins"><FlexRow><span className={styles.listIcon}><Icon icon="coins"/></span> <Coins value={reward.count!}/></FlexRow></li>);
-                case 'Mastery':
-                  return (
-                    <li key={reward.id}>
-                      <FlexRow>
-                        <span className={styles.listIcon} style={reward.region ? { '--icon-color': MasteryColors[reward.region], backgroundColor: `${MasteryColors[reward.region]}22` } : undefined}><Icon icon="mastery"/></span>
-                        <Mastery mastery={reward.region}/>
-                      </FlexRow>
-                    </li>
-                  );
-                case 'Title': {
-                  const title = achievement.rewardsTitle.find(({ id }) => id === reward.id);
-                  return (
-                    <li key={reward.id}>
-                      <FlexRow>
-                        <span className={styles.listIcon}>
-                          <Icon icon="title"/>
-                        </span>
-                        {title ? <span dangerouslySetInnerHTML={{ __html: format(localizedName(title, language)) }}/> : `Unknown (${reward.id})` }
-                      </FlexRow>
-                    </li>
-                  );
-                }
-                case 'Item': {
-                  const item = achievement.rewardsItem.find(({ id }) => id === reward.id);
-                  return (
-                    <li key={reward.id}>
-                      {item ? (<ItemLink item={item}/>) : <UnknownItem id={reward.id}/>}
-                      {reward.count && reward.count > 1 && (<span>&times;{reward.count}</span>)}
-                    </li>
-                  );
-                }
-              }
-            })}
-          </ItemList>
-        </>
-      )}
-
-      {achievement.prerequisiteFor.length > 0 && (
-        <>
-          <Headline id="prerequisiteFor">Prerequisite For</Headline>
-          <ItemList>
-            {achievement.prerequisiteFor.map((prerequisite) => (
-              <li key={prerequisite.id}><AchievementLink achievement={prerequisite}/></li>
-            ))}
-          </ItemList>
-        </>
-      )}
-
-      <Headline id="data">Data</Headline>
-      <Json data={data}/>
-    </DetailLayout>
-  );
+  return <AchievementPageComponent language={language} achievementId={achievementId}/>;
 }
 
-export default AchievementPage;
 
 export async function generateMetadata({ params }: AchievementPageProps): Promise<Metadata> {
   const { language, id: idParam } = await params;
-  const id = Number(idParam);
+  const achievementId = Number(idParam);
 
-  const achievement = await db.achievement.findUnique({
-    where: { id },
-    select: {
-      name_de: language === 'de',
-      name_en: language === 'en',
-      name_es: language === 'es',
-      name_fr: language === 'fr',
-      icon: true,
-      current_de: language === 'de' ? { select: { data: true }} : false,
-      current_en: language === 'en' ? { select: { data: true }} : false,
-      current_es: language === 'es' ? { select: { data: true }} : false,
-      current_fr: language === 'fr' ? { select: { data: true }} : false,
-    }
-  });
+  const { data } = await getRevision(achievementId, language);
 
-  if(!achievement) {
+  if(!data) {
     notFound();
   }
-
-  const data: Gw2Api.Achievement = JSON.parse(achievement[`current_${language}`].data);
 
   const description = [
     strip(data.description),
     data.requirement && strip(data.requirement.replace(/( |^)\/?( |$)/g, `$1${data.tiers[data.tiers.length - 1].count}$2`))
   ].filter(Boolean).join('\n\n');
 
+  const icon = parseIcon(data.icon);
+
   return {
-    title: localizedName(achievement, language),
+    title: data.name,
     description,
     openGraph: {
-      images: achievement.icon ? [{ url: getIconUrl(achievement.icon, 64), width: 64, height: 64, type: 'image/png' }] : []
+      images: icon ? [{ url: getIconUrl(icon, 64), width: 64, height: 64, type: 'image/png' }] : []
     },
     twitter: { card: 'summary' },
-    alternates: getAlternateUrls(`/achievement/${id}`, language),
+    alternates: getAlternateUrls(`/achievement/${achievementId}`, language),
   };
 }

--- a/apps/web/app/[language]/achievement/[id]/tier-table.tsx
+++ b/apps/web/app/[language]/achievement/[id]/tier-table.tsx
@@ -18,12 +18,12 @@ import type { Achievement } from '@gw2api/types/data/achievement';
 
 export interface TierTableProps {
   achievement: Achievement;
+  showAccounts?: boolean;
 }
 
 const requiredScopes = [Scope.GW2_Progression];
 
-export const TierTable: FC<TierTableProps> = ({ achievement }) => {
-  const accounts = useGw2Accounts(requiredScopes);
+export const TierTable: FC<TierTableProps> = ({ achievement, showAccounts = true }) => {
   const { tiers, flags } = achievement;
 
   const isRepeatable = flags.includes('Repeatable');
@@ -49,14 +49,19 @@ export const TierTable: FC<TierTableProps> = ({ achievement }) => {
           ))}
           <td align="right" className={styles.totalColumn}><b><AchievementPoints points={pointCap}/></b></td>
         </tr>
-        {!accounts.loading && !accounts.error && accounts.accounts.map((account) => (
-          <TierTableAccountRow key={account.id} achievement={achievement} account={account}/>
-        ))}
+        {showAccounts && (<TierTableAccountRows achievement={achievement}/>)}
       </tbody>
     </Table>
   );
 };
 
+const TierTableAccountRows: FC<TierTableProps> = ({ achievement }) => {
+  const accounts = useGw2Accounts(requiredScopes);
+
+  return !accounts.loading && !accounts.error && accounts.accounts.map((account) => (
+    <TierTableAccountRow key={account.id} achievement={achievement} account={account}/>
+  ));
+};
 
 interface TierTableAccountRowProps {
   achievement: Achievement;

--- a/packages/ui/components/Table/DataTable.tsx
+++ b/packages/ui/components/Table/DataTable.tsx
@@ -2,7 +2,7 @@ import { Table, type HeaderCellProps } from './Table';
 import { Fragment, Suspense, type FC, type Key, type ReactElement, type ReactNode } from 'react';
 import 'server-only';
 import { DataTableClient, DataTableClientCell, DataTableClientColumn, DataTableClientColumnSelection, DataTableClientRows } from './DataTable.client';
-import { isDefined } from '@gw2treasures/helper/is';
+import { isDefined, isTruthy } from '@gw2treasures/helper/is';
 import type { Comparable, ComparableProperties } from './comparable-properties';
 
 export type DataTableRowFilterComponentProps = { children: ReactNode, index: number };
@@ -10,7 +10,7 @@ export type DataTableRowFilterComponent = FC<DataTableRowFilterComponentProps>;
 
 // table
 export interface DataTableProps<T> {
-  children: Array<ColumnReactElement<T> | DynamicColumnsReactElement<T>>,
+  children: Array<ColumnReactElement<T> | DynamicColumnsReactElement<T> | false>,
   rowFilter?: DataTableRowFilterComponent,
   collapsed?: boolean | number,
   initialSortBy?: string,
@@ -67,7 +67,7 @@ export function createDataTable<T>(rows: T[], getRowKey: (row: T, index: number)
 
   return {
     Table: function DataTable({ children, rowFilter, collapsed = false, ...props }: DataTableProps<T>) {
-      const columns = children;
+      const columns = children.filter(isTruthy);
 
       if(columns.some((child) => child.type !== Column && child.type !== DynamicColumns)) {
         throw new Error('Column and DynamicColumns are the only allowed children of DataTable');
@@ -75,7 +75,7 @@ export function createDataTable<T>(rows: T[], getRowKey: (row: T, index: number)
 
       const rowsWithIndex = rows.map((row, index) => ({ row, index }));
 
-      const sortableColumns = Object.fromEntries(children
+      const sortableColumns = Object.fromEntries(columns
         .filter(isStaticColumn)
         .filter((column) => isDefined(column.props.sort) || isDefined(column.props.sortBy))
         .map((column) => {


### PR DESCRIPTION
This is just a copy/paste from items at the moment. This can be refactored quite a bit to avoid duplicates.

- [x] Remove accounts from `TierTable` if `fixedRevision`