### PR TITLE
Prevent search engines from indexing Mystic Forge Edit pages

### DIFF
--- a/apps/web/app/[language]/item/[id]/edit-mystic-forge/page.tsx
+++ b/apps/web/app/[language]/item/[id]/edit-mystic-forge/page.tsx
@@ -2,6 +2,7 @@ import { PageLayout } from '@/components/Layout/PageLayout';
 import { EditMysticForge } from './EditMysticForge';
 import { Headline } from '@gw2treasures/ui/components/Headline/Headline';
 import type { PageProps } from '@/lib/next';
+import type { Metadata } from 'next';
 
 export type EditMysticForgePageProps = PageProps<{ id: string }>;
 
@@ -18,6 +19,7 @@ export default async function EditMysticForgePage({ params, searchParams }: Edit
   );
 }
 
-export const metadata = {
-  title: 'Edit Mystic Forge'
+export const metadata: Metadata = {
+  title: 'Edit Mystic Forge',
+  robots: { index: false },
 };


### PR DESCRIPTION
They mostly get flagged as duplicate, and there is no point in having them discoverable on search engines.
