### PR TITLE
Use `ubuntu-22.04-arm` in CI job

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: 'Build: ${{ matrix.target }}'
-    runs-on: ${{ inputs.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.platform == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         target: [ web, worker, legacy-importer, database-migration, e2e ]


### PR DESCRIPTION
Downgrade from `ubuntu-24.04-arm` as recent comments on [this discussion](https://github.com/orgs/community/discussions/148648#discussioncomment-12099312) suggest that the `ubuntu-22.04-arm` image has less issues...