### PR TITLE
Revert "Set pnpm `verify-deps-before-run` to `prompt`"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-verify-deps-before-run=prompt


### PR DESCRIPTION
Reverts GW2Treasures/gw2treasures.com#2015

Temporarily revert this, because this fails in docker when `pnpm install` is cached. Not sure if this is caused by the pruned turbo package-lock, by pnpm or something else...