### PR TITLE
Revert "Update timescale/timescaledb Docker tag to v2.18.1"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       replicas: 2
 
   database:
-    image: timescale/timescaledb:2.18.1-pg17
+    image: timescale/timescaledb:2.18.0-pg17
     restart: unless-stopped
     environment:
       - POSTGRES_USER=gw2treasures

--- a/kubernetes/base/database/deployment.yaml
+++ b/kubernetes/base/database/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           medium: Memory
       containers:
       - name: database-pg17
-        image: timescale/timescaledb:2.18.1-pg17
+        image: timescale/timescaledb:2.18.0-pg17
         args:
         - "postgres"
         - "-c"


### PR DESCRIPTION
Reverts GW2Treasures/gw2treasures.com#2025

Reverting because of:

```raw
[1] FATAL:  database files are incompatible with server
[1] DETAIL:  The database cluster was initialized with USE_FLOAT8_BYVAL but the server was compiled without USE_FLOAT8_BYVAL.
```