### PR TITLE
Use `id` as `key` for mystic forge ingredients

### DIFF
--- a/apps/web/components/Recipe/MysticForgeIngredients.tsx
+++ b/apps/web/components/Recipe/MysticForgeIngredients.tsx
@@ -6,7 +6,7 @@ import styles from './Ingredients.module.css';
 
 interface MysticForgeIngredientsProps {
   recipe: {
-    itemIngredients: With<Pick<MysticForgeIngredientItem, 'count'>, { Item: ItemLinkProps['item'] }>[],
+    itemIngredients: With<Pick<MysticForgeIngredientItem, 'count' | 'id'>, { Item: ItemLinkProps['item'] }>[],
   }
 }
 
@@ -14,7 +14,7 @@ export const MysticForgeIngredients: FC<MysticForgeIngredientsProps> = ({ recipe
   return (
     <div className={styles.ingredients}>
       {recipe.itemIngredients.map((ingredient) => (
-        <Fragment key={ingredient.Item.id}>
+        <Fragment key={ingredient.id}>
           <div className={styles.count}>{ingredient.count}&times;</div>
           <ItemLink item={ingredient.Item} icon={16}/>
         </Fragment>


### PR DESCRIPTION
Mystic Forge recipes can use the same item multiple times
