### PR TITLE
Use FedCM for login

### DIFF
--- a/apps/web/app/[language]/layout.tsx
+++ b/apps/web/app/[language]/layout.tsx
@@ -16,6 +16,8 @@ import { DataTableContext } from '@gw2treasures/ui/components/Table/DataTableCon
 import type { ReactNode } from 'react';
 import type { LayoutProps } from '@/lib/next';
 import type { Viewport } from 'next';
+import { Gw2MeProvider } from '@/components/gw2me/gw2me-context';
+import { client_id } from '@/lib/gw2me';
 
 const bitter = Bitter({
   subsets: ['latin'],
@@ -46,10 +48,12 @@ export default async function RootLayout({ children, modal, params }: LayoutProp
             <ItemTableContext global id="global">
               <DataTableContext>
                 <UserProvider>
-                  <Gw2ApiProvider>
-                    <Layout language={language}>{children}</Layout>
-                    {modal}
-                  </Gw2ApiProvider>
+                  <Gw2MeProvider clientId={client_id} baseUrl={process.env.GW2ME_URL}>
+                    <Gw2ApiProvider>
+                      <Layout language={language}>{children}</Layout>
+                      {modal}
+                    </Gw2ApiProvider>
+                  </Gw2MeProvider>
                 </UserProvider>
               </DataTableContext>
             </ItemTableContext>

--- a/apps/web/app/[language]/login/login.action.tsx
+++ b/apps/web/app/[language]/login/login.action.tsx
@@ -1,0 +1,86 @@
+'use server';
+
+import { expiresAtFromExpiresIn } from '@/lib/expiresAtFromExpiresIn';
+import { gw2me } from '@/lib/gw2me';
+import { isValidReturnToUrl } from '@/lib/login-url';
+import { db } from '@/lib/prisma';
+import { getCurrentUrl } from '@/lib/url';
+import { Scope } from '@gw2me/client';
+import { generatePKCEPair, type PKCEChallenge } from '@gw2me/client/pkce';
+import { randomBytes } from 'crypto';
+import { redirect } from 'next/navigation';
+import 'server-only';
+
+export async function redirectToGw2Me(returnTo?: string, additionalScopes?: string) {
+
+  // build redirect url
+  const redirect_uri = new URL('/auth/callback', await getCurrentUrl()).toString();
+
+  // get scopes to request from gw2.me
+  const scopes = getScopesFromString(additionalScopes);
+
+  // prepare auth
+  const auth = await prepareAuthRequest(returnTo);
+
+  // get gw2.me auth url
+  const url = gw2me.getAuthorizationUrl({
+    scopes,
+    redirect_uri,
+    include_granted_scopes: true,
+    state: auth.state,
+    ...auth.pkce,
+  });
+
+  // redirect to gw2.me
+  redirect(url);
+}
+
+interface AuthRequest {
+  state: string,
+  pkce: PKCEChallenge,
+}
+
+export async function prepareAuthRequest(returnTo?: string): Promise<AuthRequest> {
+  const pkce = await generatePKCEPair();
+  const state = await randomBytes(16).toString('base64url');
+
+  // add expiration in 60 minutes
+  const expiresAt = expiresAtFromExpiresIn(60 * 60);
+
+  // store generated authorization request in db
+  await db.authorizationRequest.create({
+    data: {
+      state,
+      code_verifier: pkce.code_verifier,
+      returnTo: isValidReturnToUrl(returnTo) ? returnTo : undefined,
+      expiresAt,
+    }
+  });
+
+  return {
+    state,
+    pkce: pkce.challenge,
+  };
+}
+
+
+function getScopesFromString(scopeString?: string) {
+  // valid scope values to validate the provided scopes against
+  const validScopes: string[] = Object.values(Scope);
+
+  // default scopes that are always requested
+  const scopes = new Set([Scope.Identify]);
+
+  // parse scopes
+  const parsedScopes = scopeString?.split(' ') ?? [];
+
+  // add all valid scopes to the scopes set
+  for(const scope of parsedScopes) {
+    if(validScopes.includes(scope)) {
+      scopes.add(scope as Scope);
+    }
+  }
+
+  // return the array of scopes to request
+  return Array.from(scopes);
+}

--- a/apps/web/app/[language]/login/login.client.tsx
+++ b/apps/web/app/[language]/login/login.client.tsx
@@ -2,24 +2,20 @@
 
 import { Gw2MeClient, type Scope } from '@gw2me/client';
 import { SubmitButton } from '@gw2treasures/ui/components/Form/Buttons/SubmitButton';
-import { useCallback, useEffect, useMemo, type FC, type FormEventHandler } from 'react';
+import { useCallback, useEffect, type FC, type FormEventHandler } from 'react';
 import { prepareAuthRequest, redirectToGw2Me } from './login.action';
+import { useGw2MeBaseUrl, useGw2MeClient } from '@/components/gw2me/gw2me-context';
 
 export interface LoginButtonProps {
   scope: Scope[],
   returnTo?: string,
 
   logout: boolean,
-
-  clientId: string,
-  gw2meBaseUrl?: string,
 }
 
-export const LoginButton: FC<LoginButtonProps> = ({ scope, returnTo, logout, clientId, gw2meBaseUrl }) => {
-  const gw2me = useMemo(
-    () => new Gw2MeClient({ client_id: clientId }, { url: gw2meBaseUrl }),
-    [clientId, gw2meBaseUrl]
-  );
+export const LoginButton: FC<LoginButtonProps> = ({ scope, returnTo, logout }) => {
+  const gw2me = useGw2MeClient();
+  const gw2meBaseUrl = useGw2MeBaseUrl();
 
   useEffect(() => {
     // check if FedCM is supported

--- a/apps/web/app/[language]/login/login.client.tsx
+++ b/apps/web/app/[language]/login/login.client.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { Gw2MeClient, type Scope } from '@gw2me/client';
+import { SubmitButton } from '@gw2treasures/ui/components/Form/Buttons/SubmitButton';
+import { useCallback, useEffect, useMemo, type FC, type FormEventHandler } from 'react';
+import { prepareAuthRequest, redirectToGw2Me } from './login.action';
+
+export interface LoginButtonProps {
+  scope: Scope[],
+  returnTo?: string,
+
+  logout: boolean,
+
+  clientId: string,
+  gw2meBaseUrl?: string,
+}
+
+export const LoginButton: FC<LoginButtonProps> = ({ scope, returnTo, logout, clientId, gw2meBaseUrl }) => {
+  const gw2me = useMemo(
+    () => new Gw2MeClient({ client_id: clientId }, { url: gw2meBaseUrl }),
+    [clientId, gw2meBaseUrl]
+  );
+
+  useEffect(() => {
+    // check if FedCM is supported
+    if(gw2me.fedCM.isSupported()) {
+      // if the user got to the login page by logging out, prevent silent FedCM and return to not attempt passive login
+      if(logout) {
+        navigator.credentials.preventSilentAccess();
+        return;
+      }
+
+      const abort = new AbortController();
+
+      // get auth request
+      prepareAuthRequest(returnTo).then((auth) => {
+        // attemp passive FedCM login
+        gw2me.fedCM.request({
+          scopes: scope,
+          mediation: 'optional',
+          signal: abort.signal,
+          mode: 'passive',
+          ...auth.pkce,
+        }).then(handleFedCMResponse(auth.state, gw2meBaseUrl));
+      });
+
+      return () => abort.abort();
+    }
+  }, [gw2me.fedCM, gw2meBaseUrl, logout, returnTo, scope]);
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback((e) => {
+    // only handle submit if FedCM is supported
+    if(!gw2me.fedCM.isSupported()) {
+      return;
+    }
+
+    // cancel form submission
+    e.preventDefault();
+
+    prepareAuthRequest(returnTo).then((auth) => {
+      try {
+        // this is not awaited on purpose, so only sync errors are catched
+        gw2me.fedCM.request({
+          scopes: scope,
+          mediation: 'optional',
+          mode: 'active',
+          ...auth.pkce,
+        }).then(handleFedCMResponse(auth.state, gw2meBaseUrl));
+      } catch {
+        // if the FedCM request fails synchronously (bad invocation),
+        // fallback to the normal OAuth2 flow
+        redirectToGw2Me(returnTo, scope.join(' '));
+      }
+    });
+  }, [gw2me.fedCM, gw2meBaseUrl, returnTo, scope]);
+
+  return (
+    <form action={redirectToGw2Me.bind(null, returnTo, scope.join(' '))} onSubmit={handleSubmit}>
+      <SubmitButton icon="gw2me" iconColor="#b7000d" type="submit">Login with gw2.me</SubmitButton>
+    </form>
+  );
+};
+
+function handleFedCMResponse(state: string, gw2meBaseUrl: string | undefined) {
+  return (credential: Awaited<ReturnType<Gw2MeClient['fedCM']['request']>>) => {
+    if(credential) {
+      // construct custom callback URL
+      const callbackUrl = new URL('/auth/callback', location.href);
+      callbackUrl.searchParams.set('iss', gw2meBaseUrl ?? 'https://gw2.me');
+      callbackUrl.searchParams.set('state', state);
+      callbackUrl.searchParams.set('code', credential.token);
+
+      // redirect to callback url
+      location.href = callbackUrl.toString();
+    }
+  };
+}

--- a/apps/web/app/[language]/login/page.tsx
+++ b/apps/web/app/[language]/login/page.tsx
@@ -26,7 +26,7 @@ export default async function LoginPage({ searchParams }: PageProps) {
   }
 
   // parse scopes
-  const scope = parseScopeOrDefault(scopesParam);
+  const scopes = parseScopesOrDefault(scopesParam);
 
   // check if cookie exist to show logout message
   const cookieStore = await cookies();
@@ -46,7 +46,7 @@ export default async function LoginPage({ searchParams }: PageProps) {
         Login to contribute to gw2treasures.com and to view your progression, inventory, and more.
       </p>
 
-      <LoginButton scope={scope} returnTo={returnTo} logout={showLogoutMessage}/>
+      <LoginButton scopes={scopes} returnTo={returnTo} logout={showLogoutMessage}/>
 
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', padding: '12px 16px', border: '1px solid var(--color-border)', borderRadius: 2, marginTop: 32 }}>
         <Icon icon="cookie"/>
@@ -67,7 +67,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 const validScopes = new Set(Object.values(Scope));
 
-function parseScopeOrDefault(scope: string | string[] | undefined): Scope[] {
+function parseScopesOrDefault(scope: string | string[] | undefined): Scope[] {
   if(!scope) {
     return [Scope.Identify];
   }

--- a/apps/web/app/[language]/login/page.tsx
+++ b/apps/web/app/[language]/login/page.tsx
@@ -12,7 +12,6 @@ import { Trans } from '@/components/I18n/Trans';
 import type { PageProps } from '@/lib/next';
 import { cookies } from 'next/headers';
 import { LoginButton } from './login.client';
-import { client_id } from '@/lib/gw2me';
 
 export default async function LoginPage({ searchParams }: PageProps) {
   const { returnTo: returnToParam, scopes: scopesParam, error } = await searchParams;
@@ -47,7 +46,7 @@ export default async function LoginPage({ searchParams }: PageProps) {
         Login to contribute to gw2treasures.com and to view your progression, inventory, and more.
       </p>
 
-      <LoginButton scope={scope} returnTo={returnTo} logout={showLogoutMessage} clientId={client_id} gw2meBaseUrl={process.env.GW2ME_URL}/>
+      <LoginButton scope={scope} returnTo={returnTo} logout={showLogoutMessage}/>
 
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', padding: '12px 16px', border: '1px solid var(--color-border)', borderRadius: 2, marginTop: 32 }}>
         <Icon icon="cookie"/>

--- a/apps/web/components/Gw2Api/reauthorize.ts
+++ b/apps/web/components/Gw2Api/reauthorize.ts
@@ -1,13 +1,13 @@
 'use server';
+
 import { gw2me } from '@/lib/gw2me';
-import { setReturnToUrlCookie } from '@/lib/login-url';
 import { getCurrentUrl } from '@/lib/url';
 import { Scope, type AuthorizationUrlParams } from '@gw2me/client';
+import { prepareAuthRequest } from 'app/[language]/login/login.action';
 import { redirect } from 'next/navigation';
 import 'server-only';
 
 export async function reauthorize(requiredScopes: Scope[], prompt?: AuthorizationUrlParams['prompt']) {
-
   // build redirect url
   const currentUrl = await getCurrentUrl();
   const redirect_uri = new URL('/auth/callback', currentUrl).toString();
@@ -15,11 +15,17 @@ export async function reauthorize(requiredScopes: Scope[], prompt?: Authorizatio
   // get scopes
   const scopes = Array.from(new Set([Scope.Identify, Scope.Accounts, Scope.Accounts_DisplayName, ...requiredScopes]));
 
-  // get gw2.me auth url
-  const url = gw2me.getAuthorizationUrl({ redirect_uri, scopes, prompt, include_granted_scopes: true });
+  const auth = await prepareAuthRequest(currentUrl.pathname + currentUrl.search);
 
-  // add cookie for return
-  await setReturnToUrlCookie(currentUrl.pathname + currentUrl.search);
+  // get gw2.me auth url
+  const url = gw2me.getAuthorizationUrl({
+    redirect_uri,
+    scopes,
+    prompt,
+    include_granted_scopes: true,
+    state: auth.state,
+    ...auth.pkce,
+  });
 
   // redirect to gw2.me
   redirect(url);

--- a/apps/web/components/gw2me/fedcm-context.tsx
+++ b/apps/web/components/gw2me/fedcm-context.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Gw2MeClient } from '@gw2me/client';
+import { createContext, use, useCallback, type FC, type ReactNode } from 'react';
+import { useGw2MeClient } from './gw2me-context';
+import { prepareAuthRequest } from 'app/[language]/login/login.action';
+
+// TODO: export type FedCMRequestOptions from `@gw2me/client`
+type FedCMRequestOptions = Parameters<Gw2MeClient['fedCM']['request']>[0];
+
+export interface FedCMTriggerOptions extends Omit<FedCMRequestOptions, 'state' | 'code_challenge' | 'code_challenge_method'> {
+  returnTo?: string;
+}
+
+const FedCMContext = createContext<(options: FedCMTriggerOptions) => Promise<void>>(() => new Promise(() => {}));
+
+export interface FedCMProviderProps {
+  baseUrl?: string,
+  children: ReactNode,
+}
+
+export const FedCMProvider: FC<FedCMProviderProps> = ({ baseUrl, children }) => {
+  const gw2me = useGw2MeClient();
+
+  const trigger = useCallback(async ({ returnTo, ...requestOptions }: FedCMTriggerOptions) => {
+    // check if FedCM is supported
+    if(!gw2me.fedCM.isSupported()) {
+      return;
+    }
+
+    // generate state and PKCE on server
+    const auth = await prepareAuthRequest(returnTo);
+
+    // trigger actual FedCM request
+    const credential = await gw2me.fedCM.request({
+      ...requestOptions,
+      ...auth.pkce,
+    });
+
+    // check if we get a token back
+    if(credential) {
+      // generate callback url
+      const params = new URLSearchParams();
+      params.set('iss', baseUrl ?? 'https://gw2.me');
+      params.set('state', auth.state);
+      params.set('code', credential.token);
+
+      // redirect to callback url
+      location.href = `/auth/callback?${params}`;
+    }
+  }, [baseUrl, gw2me.fedCM]);
+
+  return (
+    <FedCMContext value={trigger}>
+      {children}
+    </FedCMContext>
+  );
+};
+
+export function useFedCM() {
+  return use(FedCMContext);
+}

--- a/apps/web/components/gw2me/gw2me-context.tsx
+++ b/apps/web/components/gw2me/gw2me-context.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Gw2MeClient } from '@gw2me/client';
+import { createContext, use, useMemo, type FC, type ReactNode } from 'react';
+
+const context = createContext<{ client: Gw2MeClient, baseUrl?: string } | undefined>(undefined);
+
+export interface Gw2MeProviderProps {
+  clientId: string,
+  baseUrl?: string,
+
+  children: ReactNode,
+}
+
+export const Gw2MeProvider: FC<Gw2MeProviderProps> = ({ clientId, baseUrl, children }) => {
+  const gw2me = useMemo(
+    () => ({ client: new Gw2MeClient({ client_id: clientId }, { url: baseUrl }), baseUrl }),
+    [baseUrl, clientId]
+  );
+
+  return (
+    <context.Provider value={gw2me}>
+      {children}
+    </context.Provider>
+  );
+};
+
+export function useGw2MeClient() {
+  return use(context)!.client;
+}
+
+export function useGw2MeBaseUrl() {
+  return use(context)?.baseUrl;
+}

--- a/apps/web/components/gw2me/gw2me-context.tsx
+++ b/apps/web/components/gw2me/gw2me-context.tsx
@@ -2,8 +2,9 @@
 
 import { Gw2MeClient } from '@gw2me/client';
 import { createContext, use, useMemo, type FC, type ReactNode } from 'react';
+import { FedCMProvider } from './fedcm-context';
 
-const context = createContext<{ client: Gw2MeClient, baseUrl?: string } | undefined>(undefined);
+const Gw2MeContext = createContext<Gw2MeClient | undefined>(undefined);
 
 export interface Gw2MeProviderProps {
   clientId: string,
@@ -14,21 +15,19 @@ export interface Gw2MeProviderProps {
 
 export const Gw2MeProvider: FC<Gw2MeProviderProps> = ({ clientId, baseUrl, children }) => {
   const gw2me = useMemo(
-    () => ({ client: new Gw2MeClient({ client_id: clientId }, { url: baseUrl }), baseUrl }),
+    () => new Gw2MeClient({ client_id: clientId }, { url: baseUrl }),
     [baseUrl, clientId]
   );
 
   return (
-    <context.Provider value={gw2me}>
-      {children}
-    </context.Provider>
+    <Gw2MeContext value={gw2me}>
+      <FedCMProvider baseUrl={baseUrl}>
+        {children}
+      </FedCMProvider>
+    </Gw2MeContext>
   );
 };
 
 export function useGw2MeClient() {
-  return use(context)!.client;
-}
-
-export function useGw2MeBaseUrl() {
-  return use(context)?.baseUrl;
+  return use(Gw2MeContext)!;
 }

--- a/apps/web/lib/gw2me.ts
+++ b/apps/web/lib/gw2me.ts
@@ -1,6 +1,7 @@
 import { Gw2MeClient } from '@gw2me/client';
+import 'server-only';
 
-const client_id = process.env.GW2ME_CLIENT_ID!;
+export const client_id = process.env.GW2ME_CLIENT_ID!;
 const client_secret = process.env.GW2ME_CLIENT_SECRET;
 const url = process.env.GW2ME_URL;
 

--- a/apps/web/lib/login-url.ts
+++ b/apps/web/lib/login-url.ts
@@ -1,4 +1,3 @@
-import { cookies } from 'next/headers';
 import { getCurrentUrl } from './url';
 import type { Scope } from '@gw2me/client';
 
@@ -15,38 +14,11 @@ export async function getLoginUrlWithReturnTo(scopes?: Scope[]) {
   return `/login?${parameters.toString()}`;
 }
 
-export async function getReturnToUrlFromCookie(): Promise<string> {
-  const cookieStore = await cookies();
-
-  const cookie = cookieStore.get('RETURN_TO');
-  cookieStore.delete('RETURN_TO');
-
-  return getReturnToUrl(cookie?.value);
+export function getReturnToUrl(returnTo: string | undefined | null) {
+  return isValidReturnToUrl(returnTo) ? returnTo : '/profile';
 }
 
-export function getReturnToUrl(returnTo?: string) {
-  if(returnTo && returnTo.startsWith('/')) {
-    // make sure the return to cookie does not start with a `//`, this could be an 'protocol relative' absolute url
-    if(returnTo === '/' || returnTo[1] !== '/') {
-      return returnTo;
-    }
-  }
-
-  return '/profile';
-}
-
-export async function setReturnToUrlCookie(returnTo?: string) {
-  if(!returnTo) {
-    return;
-  }
-
-  const currentUrl = await getCurrentUrl();
-
-  (await cookies()).set('RETURN_TO', returnTo, {
-    secure: true,
-    domain: currentUrl.hostname,
-    path: '/auth/callback',
-    httpOnly: true,
-    maxAge: 60 * 15 // 15 minutes
-  });
+export function isValidReturnToUrl(returnTo: string | undefined | null): returnTo is string {
+  // ensure returnTo is a relative url, but not protocol relative
+  return !!returnTo && returnTo[0] === '/' && (returnTo.length === 1 || returnTo[1] !== '/');
 }

--- a/apps/web/middleware/content-security-policy.ts
+++ b/apps/web/middleware/content-security-policy.ts
@@ -30,7 +30,7 @@ export const contentSecurityPolicyMiddleware: NextMiddleware = async (request, n
     script-src 'self' 'nonce-${nonce}' 'strict-dynamic' ${process.env.NODE_ENV !== 'production' ? '\'unsafe-eval\'' : ''};
     style-src 'self' 'unsafe-inline';
     img-src 'self' icons-gw2.darthmaim-cdn.com render.guildwars2.com wiki.guildwars2.com assets.gw2dat.com;
-    connect-src 'self' ${alternateLanguageDomains.join(' ')} api.guildwars2.com;
+    connect-src 'self' ${alternateLanguageDomains.join(' ')} api.guildwars2.com gw2.me;
     font-src 'self';
     object-src 'none';
     base-uri 'self';

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -11,6 +11,10 @@ const nextConfig: NextConfig = {
   // enable experimental features
   experimental: {
     reactCompiler: true,
+
+    // taint is not actually used, this is just to opt Next.js into using react@experimental,
+    // so other APIs become available (e.g. useEffectEvent)
+    taint: true,
   },
 
   // Allow cross-origin requests during development

--- a/packages/database/prisma/migrations/20250321181546_add_authorization_request/migration.sql
+++ b/packages/database/prisma/migrations/20250321181546_add_authorization_request/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "AuthorizationRequest" (
+    "id" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "code_verifier" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AuthorizationRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuthorizationRequest_state_key" ON "AuthorizationRequest"("state");

--- a/packages/database/prisma/migrations/20250321192000_add_return_to_to_authorization_request/migration.sql
+++ b/packages/database/prisma/migrations/20250321192000_add_return_to_to_authorization_request/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AuthorizationRequest" ADD COLUMN     "returnTo" TEXT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1443,6 +1443,18 @@ model UserProvider {
   updatedAt      DateTime   @updatedAt
 }
 
+model AuthorizationRequest {
+  id String @id @default(uuid())
+
+  state         String @unique
+  code_verifier String
+
+  returnTo String?
+
+  createdAt DateTime @default(now())
+  expiresAt DateTime
+}
+
 model Application {
   id String @id @default(uuid())
 


### PR DESCRIPTION
**TODO:**
- [x] Use PKCE for gw2.me
- [x] Use FedCM on login page
- [x] Store `returnTo` in db instead of cookie
- [x] Use silent FedCM in `Gw2ApiProvider` if logged out
- [ ] Use active FedCM to reauthorize?
- [x] Set `returnTo` and `scopes` in `Gw2ApiProvider` for login url