### PR TITLE
Revert web CPU limit changes

### DIFF
--- a/kubernetes/base/next/deployment.yaml
+++ b/kubernetes/base/next/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             cpu: "100m"
           limits:
             memory: "512Mi"
-            cpu: "500m"
+            cpu: "1"
         env:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
During requests the process always got throttled, which resulted in slower response times.

See #2228
See #2231
