### PR TITLE
Set user-agent and encode `<` and `>` for SMW queries

### DIFF
--- a/apps/worker/src/jobs/items/containerContent.ts
+++ b/apps/worker/src/jobs/items/containerContent.ts
@@ -42,7 +42,11 @@ export const ItemsContainerContent: Job = {
       const query = `[[Contained in.Has game id::${id}]][[Has context::Container item]][[Contained in.Has context::Item]][[Contains item.Has context::Item]][[Contains item.Is historical::False]]|?Contained in.Has game id=ContainerId|?Contains item.Has game id=ContentId|?Has contained item chance=Chance|?Has contained item quantity=Quantity`;
       const url = `https://wiki.guildwars2.com/api.php?action=ask&query=${encodeURIComponent(query)}&format=json`;
 
-      const result = await fetch(url).then((r) => r.json()) as WikiAskResponse;
+      const headers = {
+        'User-Agent': 'Mozilla/5.0 (compatible; gw2treasures.com/1.0; +https://gw2treasures.com/)'
+      };
+
+      const result = await fetch(url, { headers }).then((r) => r.json()) as WikiAskResponse;
 
       const contents = Object.values(result.query.results).map<Prisma.ContentCreateManyInput>((entry) => ({
         containerItemId: id,

--- a/apps/worker/src/jobs/skins/appearance.ts
+++ b/apps/worker/src/jobs/skins/appearance.ts
@@ -48,13 +48,19 @@ export const SkinsWikiJob: Job = {
       return 'Queued follow up jobs';
     }
 
-    const query = `[[Has context::Skin]][[Has game id::≥${offset}]][[Has game id::<<${offset + batchSize}]]|?Has game id|?Has appearance|?Has skin set.Has appearance=Has set appearance|?Has skin set|limit=${batchSize}`;
+    const query = `[[Has context::Skin]][[Has game id::>>${offset - 1}]][[Has game id::<<${offset + batchSize}]]|?Has game id|?Has appearance|?Has skin set.Has appearance=Has set appearance|?Has skin set|limit=${batchSize}`
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
     const url = `https://wiki.guildwars2.com/api.php?action=ask&query=${encodeURIComponent(query)}&format=json`;
 
     console.log('> Fetch data for skins from wiki');
     console.log(url);
 
-    const data = await fetch(url).then((r) => {
+    const headers = {
+      'User-Agent': 'Mozilla/5.0 (compatible; gw2treasures.com/1.0; +https://gw2treasures.com/)'
+    };
+
+    const data = await fetch(url, { headers }).then((r) => {
       if(r.status !== 200) {
         throw new Error(`${url} returned ${r.status} ${r.statusText}`);
       }


### PR DESCRIPTION
The firewall of the wiki started blocking requests containing `<` or `>` without useragents some weeks ago...
