### PR TITLE
Show warning for missing weekly wizards vault objectives.

### DIFF
--- a/apps/web/app/[language]/wizards-vault/(index)/objectives.tsx
+++ b/apps/web/app/[language]/wizards-vault/(index)/objectives.tsx
@@ -142,7 +142,7 @@ const AccountObjectiveDetails: FC<AccountObjectivesProps> = ({ account, objectiv
 
   return (
     <>
-      {wizardsVault.daily === null && <Notice>This account has not logged in to the game since the last reset. Not all objectives can be shown and special objectives may be outdated.</Notice>}
+      {(wizardsVault.daily === null || wizardsVault.weekly === null) && <Notice>This account has not logged in to the game since the last reset. Not all objectives can be shown and special objectives may be outdated.</Notice>}
 
       <Table>
         <thead>


### PR DESCRIPTION
Since daily objectives reset at midnight UTC, but weeklies at 07:30 UTC, it is possible that people have logged in since last daily reset, but not since last weekly.
