### PR TITLE
Replace `GW2T_NEXT_DOMAIN` with `GW2T_URL` env variable

### DIFF
--- a/apps/web/.env
+++ b/apps/web/.env
@@ -5,4 +5,4 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="postgresql://gw2treasures:gw2treasures@localhost:54326/gw2treasures?schema=public"
-GW2T_NEXT_DOMAIN="gw2treasures.localhost"
+GW2T_URL="http://gw2treasures.localhost:3000"

--- a/apps/web/app/[language]/(manifest)/.well-known/web-app-origin-association/route.ts
+++ b/apps/web/app/[language]/(manifest)/.well-known/web-app-origin-association/route.ts
@@ -1,14 +1,11 @@
-import { getCurrentUrl } from '@/lib/url';
+import { getBaseUrl } from '@/lib/url';
 import { Language } from '@gw2treasures/database';
 import { NextResponse } from 'next/server';
 
-export async function GET() {
-  const currentUrl = await getCurrentUrl();
-  const protocol = currentUrl.protocol;
-
+export function GET() {
   return NextResponse.json(Object.fromEntries(
     Object.values(Language).map((language) => [
-      `${protocol}//${language}.${process.env.GW2T_NEXT_DOMAIN}`,
+      getBaseUrl(language).origin,
       { scope: '/' }
     ])
   ));

--- a/apps/web/app/[language]/(manifest)/site.webmanifest/route.ts
+++ b/apps/web/app/[language]/(manifest)/site.webmanifest/route.ts
@@ -1,11 +1,8 @@
-import { getCurrentUrl } from '@/lib/url';
+import { getBaseUrl } from '@/lib/url';
 import { Language } from '@gw2treasures/database';
 import { NextResponse } from 'next/server';
 
-export async function GET() {
-  const currentUrl = await getCurrentUrl();
-  const protocol = currentUrl.protocol;
-
+export function GET() {
   return NextResponse.json({
     id: '/',
     name: 'gw2treasures.com',
@@ -35,7 +32,7 @@ export async function GET() {
     theme_color: '#b7000d',
     background_color: '#ffffff',
     display: 'standalone',
-    scope_extensions: Object.values(Language).map((language) => ({ type: 'origin', origin: `${protocol}//${language}.${process.env.GW2T_NEXT_DOMAIN}` }))
+    scope_extensions: Object.values(Language).map((language) => ({ type: 'origin', origin: getBaseUrl(language).origin }))
   }, {
     headers: {
       'content-type': 'application/manifest+json'

--- a/apps/web/app/[language]/dev/api/page.tsx
+++ b/apps/web/app/[language]/dev/api/page.tsx
@@ -2,7 +2,7 @@ import { Code } from '@/components/Layout/Code';
 import { HeroLayout } from '@/components/Layout/HeroLayout';
 import { Highlight } from '@/components/Layout/Highlight';
 import { ExternalLink } from '@gw2treasures/ui/components/Link/ExternalLink';
-import { getCurrentUrl } from '@/lib/url';
+import { getBaseUrl } from '@/lib/url';
 import { Headline } from '@gw2treasures/ui/components/Headline/Headline';
 import { Table } from '@gw2treasures/ui/components/Table/Table';
 import Link from 'next/link';
@@ -28,10 +28,8 @@ const containerContentsSchema =
   >
 }>`;
 
-export default async function DeveloperIconsPage() {
-  const apiUrl = await getCurrentUrl();
-  apiUrl.hostname = `api.${process.env.GW2T_NEXT_DOMAIN}`;
-  apiUrl.pathname = '/';
+export default function DeveloperIconsPage() {
+  const apiUrl = getBaseUrl('api');
 
   return (
     <HeroLayout hero={<Headline id="api">API</Headline>} color="#2c8566" toc>

--- a/apps/web/app/[language]/layout.tsx
+++ b/apps/web/app/[language]/layout.tsx
@@ -21,6 +21,7 @@ import { client_id } from '@/lib/gw2me';
 import { AchievementProgressTypeProvider } from '@/components/Achievement/AchievementProgressTypeContext';
 import { getLanguage } from '@/lib/translate';
 import { SynchronizedTimeProvider } from '@/components/Time/synchronized-time';
+import { getBaseUrl } from '@/lib/url';
 
 const bitter = Bitter({
   subsets: ['latin'],
@@ -40,7 +41,7 @@ export default async function RootLayout({ children, modal }: LayoutProps & { mo
   const language = await getLanguage();
 
   return (
-    <html lang={language} className={cx(bitter.variable, wotfard.variable)}>
+    <html lang={language} className={cx(bitter.variable, wotfard.variable)} data-base-url={getBaseUrl().toString()}>
       <head>
         <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#b7000d"/>
       </head>

--- a/apps/web/app/api/route.ts
+++ b/apps/web/app/api/route.ts
@@ -1,15 +1,11 @@
 import { getLanguage } from '@/lib/translate';
-import { getCurrentUrl } from '@/lib/url';
+import { getBaseUrl } from '@/lib/url';
 import { NextResponse } from 'next/server';
-
-const baseDomain = process.env.GW2T_NEXT_DOMAIN!;
 
 export async function GET() {
   const language = await getLanguage();
 
-  const documentation = await getCurrentUrl();
-  documentation.hostname = baseDomain;
-  documentation.pathname = '/dev/api';
+  const documentation = new URL('/dev/api', getBaseUrl());
 
   return NextResponse.json({ api: true, language, documentation });
 }

--- a/apps/web/lib/auth/cookie.ts
+++ b/apps/web/lib/auth/cookie.ts
@@ -1,6 +1,5 @@
 import type { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
-
-const baseDomain = process.env.GW2T_NEXT_DOMAIN;
+import { getBaseUrl } from '../url';
 
 /** Name of session cookie */
 export const SessionCookieName = 'gw2t-session';
@@ -12,7 +11,7 @@ export const expiresIn = 365 * 24 * 60 * 60; // 1 year
 export const authCookieSettings: Omit<ResponseCookie, 'value' | 'expires'> = {
   name: SessionCookieName,
 
-  domain: baseDomain,
+  domain: '.' + getBaseUrl().hostname,
   sameSite: 'lax',
   httpOnly: true,
   priority: 'high',

--- a/apps/web/lib/localizedUrl.ts
+++ b/apps/web/lib/localizedUrl.ts
@@ -1,18 +1,11 @@
 import type { Language } from '@gw2treasures/database';
 
 export function localizedUrl(href: string, language: Language) {
-  const base = process.env.GW2T_NEXT_DOMAIN;
+  // get base url from env variable on server or html[data-base-url] on client
+  const baseUrl = process.env.GW2T_URL ?? document.documentElement.dataset.baseUrl!;
 
-  if(typeof window === 'undefined') {
-    // TODO: server side
-    const url = new URL(href, `http://${language}.${base}/`);
-    return url.href;
-  }
+  const base = new URL(baseUrl);
+  base.hostname = `${language}.${base.hostname}`;
 
-  const currentUrl = new URL(window.location.href);
-
-  const newUrl = new URL(href, currentUrl);
-  newUrl.hostname = language + currentUrl.hostname.substring(2);
-
-  return newUrl.href;
+  return new URL(href, base).toString();
 }

--- a/apps/web/middleware/cors.ts
+++ b/apps/web/middleware/cors.ts
@@ -1,10 +1,10 @@
 import { Language } from '@gw2treasures/database';
 import type { NextMiddleware } from './types';
 import { NextResponse } from 'next/server';
+import { getBaseUrl } from '@/lib/url';
 
 const languages = Object.values(Language);
-const baseDomain = process.env.GW2T_NEXT_DOMAIN;
-const regex = new RegExp(`^https?://(${languages.join('|')})\\.${baseDomain?.replace('.', '\\.')}`);
+const validOrigins = languages.map((language) => getBaseUrl(language).origin);
 
 export const corsMiddleware: NextMiddleware = async (request, next, data) => {
   // skip this middleware for API
@@ -16,7 +16,7 @@ export const corsMiddleware: NextMiddleware = async (request, next, data) => {
 
   // allow the request if the origin is not set (no CORS request)
   // or if it matches the baseDomain
-  const isAllowed = !origin || origin.match(regex);
+  const isAllowed = !origin || validOrigins.includes(origin);
 
   if(!isAllowed) {
     console.error('Blocked CORS request.');

--- a/apps/web/middleware/language.ts
+++ b/apps/web/middleware/language.ts
@@ -3,8 +3,7 @@ import { Language } from '@gw2treasures/database';
 import { NextResponse } from 'next/server';
 import { match } from '@formatjs/intl-localematcher';
 import Negotiator from 'negotiator';
-
-const baseDomain = process.env.GW2T_NEXT_DOMAIN;
+import { getBaseUrl } from '@/lib/url';
 
 export const languageMiddleware: NextMiddleware = (request, next, data) => {
   const url = data.url;
@@ -21,9 +20,9 @@ export const languageMiddleware: NextMiddleware = (request, next, data) => {
 
     const language = acceptLanguage.length === 1 && acceptLanguage[0] === '*'
       ? Language.en
-      : match(acceptLanguage, Object.values(Language), Language.en);
+      : match(acceptLanguage, Object.values(Language), Language.en) as Language;
 
-    url.hostname = `${language}.${baseDomain}`;
+    url.hostname = getBaseUrl(language).hostname;
 
     // if we attempted to do this already, show error
     if(request.cookies.has('redirect_loop')) {

--- a/apps/web/middleware/subdomain.ts
+++ b/apps/web/middleware/subdomain.ts
@@ -1,10 +1,10 @@
+import { getBaseUrl } from '@/lib/url';
 import type { NextMiddleware } from './types';
 import { Language } from '@gw2treasures/database';
 import { NextResponse } from 'next/server';
 
 type Subdomain = Language | 'api';
 const validSubdomains: Subdomain[] = ['api', ...Object.values(Language)];
-const baseDomain = process.env.GW2T_NEXT_DOMAIN;
 
 declare module './types' {
   interface NextMiddlewareData {
@@ -20,7 +20,7 @@ export const subdomainMiddleware: NextMiddleware = (request, next, data) => {
   }
 
   // find the subdomain by parsing the hostname
-  const subdomain = validSubdomains.find((subdomain) => url.hostname === `${subdomain}.${baseDomain}`);
+  const subdomain = validSubdomains.find((subdomain) => url.hostname === getBaseUrl(subdomain).hostname);
   data.subdomain = subdomain;
 
   return next(request);

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -10,7 +10,7 @@ services:
 
   web:
     environment:
-      - GW2T_NEXT_DOMAIN=gw2treasures.docker
+      - GW2T_URL=http://gw2treasures.docker:3000
     networks:
       default:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     restart: unless-stopped
     environment:
       - DATABASE_URL=postgresql://gw2treasures:gw2treasures@database:5432/gw2treasures?schema=public
-      - GW2T_NEXT_DOMAIN=gw2treasures.localhost
-      - HTTPS=0
+      - GW2T_URL=http://gw2treasures.localhost:3000
       - FORCE_COLOR=1
     ports:
       - 3000:3000

--- a/kubernetes/base/next/deployment.yaml
+++ b/kubernetes/base/next/deployment.yaml
@@ -42,11 +42,11 @@ spec:
             configMapKeyRef:
               name: next
               key: db
-        - name: GW2T_NEXT_DOMAIN
+        - name: GW2T_URL
           valueFrom:
             configMapKeyRef:
               name: next
-              key: domain
+              key: url
         - name: GW2ME_CLIENT_ID
           valueFrom:
             configMapKeyRef:

--- a/kubernetes/local/next/configMap.yaml
+++ b/kubernetes/local/next/configMap.yaml
@@ -6,5 +6,5 @@ metadata:
 
 data:
   db: postgresql://gw2treasures:f51f6aa0-73a7-45de-a068-6867fec97dc2@database-pg17:5432/gw2treasures?schema=public
-  domain: next.gw2treasures.kubernetes.localhost
+  url: http://next.gw2treasures.kubernetes.localhost
   signing_key: eyJrZXlfb3BzIjpbInNpZ24iLCJ2ZXJpZnkiXSwiZXh0Ijp0cnVlLCJrdHkiOiJvY3QiLCJrIjoiclBSR0dPRlVRSXFOZlZ4dE5PWXR5QTRXTUliUTB2TW5WcFlxcnJuSFo5SSIsImFsZyI6IkhTMjU2In0=


### PR DESCRIPTION
The previous variable `GW2T_NEXT_DOMAIN` required "guessing" the protocol/port based on proxy headers, this new variable is now the full URL, and we can just use its `origin`/`host`/`hostname`/... wherever needed