### PR TITLE
Ignore minimum release age for playwright docker image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,7 @@
     }, {
       "matchDatasources": ["docker"],
       "matchDepNames": ["mcr.microsoft.com/playwright"],
+      "minimumReleaseAge": null,
       "groupName": "playwright"
     }, {
       "description": "Group Docker GitHub Actions",


### PR DESCRIPTION
Unset `minimumReleaseAge` in the renovate config for the playwright docker image, as the release timestamp is not available in the microsoft registry metadata and renovate would never update the image because of this.

<details>
<summary>Relevant log</summary>

```raw
{
  "name":"renovate",
  "hostname":"jr-microvm",
  "pid":725,
  "level":20,
  "logContext":"7426246c-d9a3-4c36-8353-cc0e275ba39e",
  "repository":"GW2Treasures/gw2treasures.com",
  "depName":"mcr.microsoft.com/playwright",
  "versions":["v1.61.1-jammy","v1.61.0-jammy"],
  "check":"minimumReleaseAge",
  "msg":"Marking 2 release(s) as pending, as they do not have a releaseTimestamp and we're running with minimumReleaseAgeBehaviour=timestamp-required",
  "time":"2026-07-14T19:08:51.979Z",
  "v":0
}
```

</details>