### PR TITLE
Group prisma dependency update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,10 @@
       "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
       "groupName": "react"
     }, {
+      "matchDatasources": ["npm"],
+      "matchDepNames": ["prisma", "@prisma/**"],
+      "groupName": "prisma"
+    }, {
       "matchManagers": ["npm"],
       "matchPackageNames": ["@floating-ui/**"],
       "groupName": "floating-ui"


### PR DESCRIPTION
Not sure why renovate is not grouping these anymore without a custom rule